### PR TITLE
Fix time constant typo

### DIFF
--- a/apps/server/src/utils/dates.test.ts
+++ b/apps/server/src/utils/dates.test.ts
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import { oneDayInSeconds, oneWeekInSeconds } from './dates';
+
+describe('dates utilities', () => {
+    it('oneWeekInSeconds should equal seven days', () => {
+        expect(oneWeekInSeconds).to.equal(oneDayInSeconds * 7);
+    });
+});

--- a/apps/server/src/utils/dates.ts
+++ b/apps/server/src/utils/dates.ts
@@ -1,7 +1,7 @@
 export const oneMinInSeconds = 60;
 export const oneHourInSeconds = oneMinInSeconds * 60;
 export const oneDayInSeconds = oneHourInSeconds * 24;
-export const oneWeekInSeconds = oneHourInSeconds * 24;
+export const oneWeekInSeconds = oneDayInSeconds * 7;
 export const oneMonthInSeconds = oneDayInSeconds * 30;
 
 export const oneMinInMillis = 1000 * 60;


### PR DESCRIPTION
## Summary
- correct constant for oneWeekInSeconds
- add a unit test covering this utility

## Testing
- `yarn workspace MemoryFlashServer test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683fd64d4bb4832892229b9a86eaf40d