### PR TITLE
Fix dark mode input background

### DIFF
--- a/apps/react/src/components/inputs/BaseInput.tsx
+++ b/apps/react/src/components/inputs/BaseInput.tsx
@@ -6,7 +6,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
 	({ className = '', ...props }, ref) => (
 		<input
 			ref={ref}
-			className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 ${className}`}
+			className={`block w-full rounded-md border-0 py-1.5 bg-white dark:bg-gray-800 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 ${className}`}
 			{...props}
 		/>
 	),


### PR DESCRIPTION
## Summary
- ensure BaseInput uses dark background in dark mode

## Testing
- `yarn test` *(fails: Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_6843b659bda88328aa52693d773fcdf6