### PR TITLE
Fix Playwright install order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,16 +35,11 @@ jobs:
               with:
                   mongodb-version: ${{ matrix.mongodb-version }}
 
-            - name: Run unit tests
-              run: yarn test
-              env:
-                  APP_URL: http://0.0.0.0:8008
-
             - name: Install Playwright browsers
               working-directory: apps/react
               run: npx playwright install --with-deps
 
-            - name: Run screenshot tests
-              run: yarn workspace MemoryFlashReact test:screenshots
+            - name: Run unit tests
+              run: yarn test
               env:
                   APP_URL: http://0.0.0.0:8008


### PR DESCRIPTION
## Summary
- install Playwright browsers before tests and remove duplicate screenshot step

## Testing
- `yarn test` *(fails: Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_6843bebb084c832896c623e993d43ab3