### PR TITLE
Fix deploy server yarn command

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -30,7 +30,7 @@ jobs:
                   credentials_json: ${{ secrets.GCP_MFLASH_PROD_JSON_KEY }}
             - name: Build and Deploy
               run: |
-                  yarn install --hoist
+                  yarn install
                   touch app.yaml
                   echo 'runtime: nodejs20' >> app.yaml
                   echo 'env: standard' >> app.yaml


### PR DESCRIPTION
## Summary
- remove `--hoist` option from deploy-server action since Yarn 4 doesn't support it

## Testing
- `yarn test`
- `npx prettier --write .github/workflows/deploy-server.yml`

------
https://chatgpt.com/codex/tasks/task_e_684e756e7aa88328b41b2dd4eb4c5e32