### PR TITLE
Add music notation length tests

### DIFF
--- a/apps/react/music-notation-eighth-test.html
+++ b/apps/react/music-notation-eighth-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicNotation Eighth Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/music-notation-eighth-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/music-notation-half-quarter-test.html
+++ b/apps/react/music-notation-half-quarter-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicNotation Half Quarter Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/music-notation-half-quarter-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/src/music-notation-eighth-test.tsx
+++ b/apps/react/src/music-notation-eighth-test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { MusicNotation } from './components/MusicNotation';
+import './index.css';
+import { createStore } from 'MemoryFlashCore/src/redux/store';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+
+const indexParam = new URLSearchParams(window.location.search).get('index');
+const multiPartCardIndex = indexParam ? parseInt(indexParam, 10) : 0;
+
+const store = createStore({ scheduler: { multiPartCardIndex } } as any, () => {});
+(window as any).store = store;
+
+const data: MultiSheetQuestion = {
+	key: 'C',
+	voices: [
+		{
+			staff: StaffEnum.Treble,
+			stack: [
+				{ notes: [{ name: 'C', octave: 4 }], duration: '8' },
+				{ notes: [{ name: 'D', octave: 4 }], duration: '8' },
+				{ notes: [{ name: 'E', octave: 4 }], duration: '8' },
+				{ notes: [{ name: 'F', octave: 4 }], duration: '8' },
+				{ notes: [{ name: 'G', octave: 4 }], duration: '8' },
+				{ notes: [{ name: 'A', octave: 4 }], duration: '8' },
+				{ notes: [{ name: 'B', octave: 4 }], duration: '8' },
+				{ notes: [{ name: 'C', octave: 5 }], duration: '8' },
+			],
+		},
+	],
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+	<React.StrictMode>
+		<Provider store={store}>
+			<MusicNotation data={data} highlightClassName="highlight" />
+		</Provider>
+	</React.StrictMode>,
+);

--- a/apps/react/src/music-notation-half-quarter-test.tsx
+++ b/apps/react/src/music-notation-half-quarter-test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { MusicNotation } from './components/MusicNotation';
+import './index.css';
+import { createStore } from 'MemoryFlashCore/src/redux/store';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+
+const indexParam = new URLSearchParams(window.location.search).get('index');
+const multiPartCardIndex = indexParam ? parseInt(indexParam, 10) : 0;
+
+const store = createStore({ scheduler: { multiPartCardIndex } } as any, () => {});
+(window as any).store = store;
+
+const data: MultiSheetQuestion = {
+	key: 'C',
+	voices: [
+		{
+			staff: StaffEnum.Treble,
+			stack: [
+				{
+					notes: [
+						{ name: 'C', octave: 4 },
+						{ name: 'E', octave: 4 },
+						{ name: 'G', octave: 4 },
+					],
+					duration: 'h',
+					chordName: 'C',
+				},
+				{ notes: [{ name: 'D', octave: 4 }], duration: 'q' },
+				{ notes: [{ name: 'E', octave: 4 }], duration: 'q' },
+			],
+		},
+	],
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+	<React.StrictMode>
+		<Provider store={store}>
+			<MusicNotation data={data} highlightClassName="highlight" />
+		</Provider>
+	</React.StrictMode>,
+);

--- a/apps/react/tests/helpers.ts
+++ b/apps/react/tests/helpers.ts
@@ -1,0 +1,1 @@
+export const screenshotOpts = { maxDiffPixelRatio: 0.02 };

--- a/apps/react/tests/music-notation-eighth.spec.ts
+++ b/apps/react/tests/music-notation-eighth.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+import { screenshotOpts } from './helpers';
+
+test('MusicNotation eighth notes screenshot', async ({ page }) => {
+	await page.goto('/music-notation-eighth-test.html');
+	const output = page.locator('#output');
+	await output.waitFor();
+	await expect(output).toHaveScreenshot('music-notation-eighth.png', screenshotOpts);
+});

--- a/apps/react/tests/music-notation-half-quarter.spec.ts
+++ b/apps/react/tests/music-notation-half-quarter.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+import { screenshotOpts } from './helpers';
+
+test('MusicNotation half and quarter notes screenshot', async ({ page }) => {
+	await page.goto('/music-notation-half-quarter-test.html');
+	const output = page.locator('#output');
+	await output.waitFor();
+	await expect(output).toHaveScreenshot('music-notation-half-quarter.png', screenshotOpts);
+});

--- a/apps/react/tests/music-notation-highlight.spec.ts
+++ b/apps/react/tests/music-notation-highlight.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { screenshotOpts } from './helpers';
 
 test.describe('highlight notes', () => {
 	for (const index of [1, 2, 3, 4]) {
@@ -6,9 +7,7 @@ test.describe('highlight notes', () => {
 			await page.goto(`/music-notation-test.html?index=${index}`);
 			const output = page.locator('#output');
 			await output.waitFor();
-			await expect(output).toHaveScreenshot(`highlight-${index}.png`, {
-				maxDiffPixelRatio: 0.02,
-			});
+			await expect(output).toHaveScreenshot(`highlight-${index}.png`, screenshotOpts);
 		});
 	}
 });

--- a/apps/react/tests/music-notation.spec.ts
+++ b/apps/react/tests/music-notation.spec.ts
@@ -1,10 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { screenshotOpts } from './helpers';
 
 test('MusicNotation component screenshot', async ({ page }) => {
 	await page.goto('/music-notation-test.html');
 	const output = page.locator('#output');
 	await output.waitFor();
-	await expect(output).toHaveScreenshot('music-notation.png', {
-		maxDiffPixelRatio: 0.02,
-	});
+	await expect(output).toHaveScreenshot('music-notation.png', screenshotOpts);
 });


### PR DESCRIPTION
## Summary
- add new React pages for half+quarter notes and for eighth notes
- add corresponding Playwright screenshot tests
- remove binary screenshot files from version control
- share screenshot options via helper

## Testing
- `yarn workspace MemoryFlashReact test:screenshots:update`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684e7039dd0083289b55d80f01bade31