### PR TITLE
Add keyboard notation input screen

### DIFF
--- a/apps/react/src/App.tsx
+++ b/apps/react/src/App.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { StudyScreen } from './components';
 import { MidiToRedux } from './components/MidiToRedux';
 import { AuthenticatedRoute } from './components/navigation/Routers';
-import { CoursesScreen } from './screens';
+import { CoursesScreen, NotationInputScreen } from './screens';
 import { AllDeckCardsScreen } from './screens/AllDeckCardsScreen';
 import { DecksScreen } from './screens/DecksScreen';
 import { LoginScreen } from './screens/LoginScreen';
@@ -36,6 +36,7 @@ export default function App() {
 						path="/account"
 						element={<AuthenticatedRoute screen={<AccountScreen />} />}
 					/>
+					<Route path="/notation" element={<NotationInputScreen />} />
 					<Route
 						path="/course/:courseId"
 						element={<AuthenticatedRoute screen={<DecksScreen />} />}

--- a/apps/react/src/components/inputs/Select.tsx
+++ b/apps/react/src/components/inputs/Select.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+	({ className = '', children, ...props }, ref) => (
+		<select
+			ref={ref}
+			className={`block w-full rounded-md border-0 py-1.5 bg-white dark:bg-gray-800 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm ${className}`}
+			{...props}
+		>
+			{children}
+		</select>
+	),
+);
+Select.displayName = 'Select';

--- a/apps/react/src/components/inputs/index.ts
+++ b/apps/react/src/components/inputs/index.ts
@@ -1,3 +1,4 @@
 export * from './BaseInput';
 export * from './InputField';
 export * from './EmailInput';
+export * from './Select';

--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Midi } from 'tonal';
+import { Layout } from '../components';
+import { MusicNotation } from '../components/MusicNotation';
+import { Select } from '../components/inputs';
+import { majorKeys } from 'MemoryFlashCore/src/lib/notes';
+import { buildMultiSheetQuestion } from 'MemoryFlashCore/src/lib/notationBuilder';
+import { StackedNotes } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
+import usePrevious from '../utils/usePrevious';
+
+const NoteSettings: React.FC<{
+	keySig: string;
+	setKeySig: (k: string) => void;
+	dur: StackedNotes['duration'];
+	setDur: (d: StackedNotes['duration']) => void;
+}> = ({ keySig, setKeySig, dur, setDur }) => (
+	<div className="flex gap-4 pb-4">
+		<label className="flex items-center gap-2">
+			Key
+			<Select value={keySig} onChange={(e) => setKeySig(e.target.value)}>
+				{majorKeys.map((k) => (
+					<option key={k}>{k}</option>
+				))}
+			</Select>
+		</label>
+		<label className="flex items-center gap-2">
+			Duration
+			<Select value={dur} onChange={(e) => setDur(e.target.value as any)}>
+				{['w', 'h', 'q', '8', '16'].map((d) => (
+					<option key={d} value={d}>
+						{d}
+					</option>
+				))}
+			</Select>
+		</label>
+	</div>
+);
+
+export const NotationInputScreen = () => {
+	const [notes, setNotes] = useState<StackedNotes[]>([]);
+	const [keySig, setKeySig] = useState(majorKeys[0]);
+	const [dur, setDur] = useState<StackedNotes['duration']>('q');
+	const midiNotes = useAppSelector((s) => s.midi.notes);
+	const prevMidi = usePrevious(midiNotes);
+
+	useEffect(() => {
+		midiNotes.forEach((n) => {
+			if (prevMidi?.find((p) => p.number === n.number)) return;
+			const noteName = Midi.midiToNoteName(n.number);
+			const [name, octaveStr] = noteName.split(/(?=\d)/);
+			setNotes((p) => [
+				...p,
+				{ notes: [{ name, octave: Number(octaveStr) }], duration: dur },
+			]);
+		});
+	}, [midiNotes, prevMidi, dur]);
+
+	const data = buildMultiSheetQuestion(notes, keySig);
+
+	return (
+		<Layout subtitle="Notation Input" back="/">
+			<NoteSettings keySig={keySig} setKeySig={setKeySig} dur={dur} setDur={setDur} />
+			<MusicNotation data={data} />
+		</Layout>
+	);
+};

--- a/apps/react/src/screens/index.ts
+++ b/apps/react/src/screens/index.ts
@@ -1,1 +1,2 @@
 export * from './CoursesScreen';
+export * from './NotationInputScreen';

--- a/apps/server/src/utils/notationBuilder.test.ts
+++ b/apps/server/src/utils/notationBuilder.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { addRests } from 'MemoryFlashCore/src/lib/notationBuilder';
+import { StackedNotes } from 'MemoryFlashCore/src/types/MultiSheetCard';
+
+describe('addRests', () => {
+	it('fills a simple remainder', () => {
+		const notes: StackedNotes[] = [
+			{ notes: [{ name: 'C', octave: 4 }], duration: 'h' },
+			{ notes: [{ name: 'D', octave: 4 }], duration: 'q' },
+		];
+		const res = addRests(notes);
+		expect(res.map((n) => n.duration)).to.eql(['h', 'q', 'qr']);
+	});
+
+	it('handles complex remainder', () => {
+		const notes: StackedNotes[] = [
+			{ notes: [{ name: 'C', octave: 4 }], duration: 'h' },
+			{ notes: [{ name: 'D', octave: 4 }], duration: '8' },
+		];
+		const res = addRests(notes);
+		expect(res.slice(2).map((n) => n.duration)).to.eql(['qr', '8r']);
+	});
+
+	it('returns same array when full', () => {
+		const notes: StackedNotes[] = [
+			{ notes: [{ name: 'C', octave: 4 }], duration: 'h' },
+			{ notes: [{ name: 'D', octave: 4 }], duration: 'h' },
+		];
+		const res = addRests(notes);
+		expect(res.length).to.equal(2);
+	});
+});

--- a/packages/MemoryFlashCore/src/lib/notationBuilder.ts
+++ b/packages/MemoryFlashCore/src/lib/notationBuilder.ts
@@ -1,0 +1,54 @@
+import { StaffEnum } from '../types/Cards';
+import { MultiSheetQuestion, StackedNotes, Voice } from '../types/MultiSheetCard';
+
+const DURATIONS: Array<[StackedNotes['duration'], number]> = [
+	['w', 4],
+	['h', 2],
+	['q', 1],
+	['8', 0.5],
+	['16', 0.25],
+];
+
+const beatsOf = (duration: StackedNotes['duration']): number => {
+	const base = duration.replace('r', '') as StackedNotes['duration'];
+	const entry = DURATIONS.find(([d]) => d === base);
+	return entry ? entry[1] : 0;
+};
+
+const beatsToDurations = (beats: number): StackedNotes['duration'][] => {
+	const durs: StackedNotes['duration'][] = [];
+	for (const [dur, val] of DURATIONS) {
+		while (beats >= val - 1e-6) {
+			durs.push(`${dur}r` as StackedNotes['duration']);
+			beats -= val;
+		}
+	}
+	return durs;
+};
+
+export const addRests = (notes: StackedNotes[]): StackedNotes[] => {
+	const total = notes.reduce((s, n) => s + beatsOf(n.duration), 0);
+	const remainder = 4 - (total % 4);
+	if (remainder === 4 || remainder === 0) return notes;
+	return [
+		...notes,
+		...beatsToDurations(remainder).map((duration) => ({
+			notes: [{ name: 'b', octave: 4 }],
+			duration,
+		})),
+	];
+};
+
+export const buildMultiSheetQuestion = (notes: StackedNotes[], key: string): MultiSheetQuestion => {
+	const filled = addRests(notes);
+	const treble: StackedNotes[] = [];
+	const bass: StackedNotes[] = [];
+	filled.forEach((n) => {
+		if (n.notes[0].octave >= 4) treble.push(n);
+		else bass.push(n);
+	});
+	const voices: Voice[] = [];
+	if (treble.length) voices.push({ staff: StaffEnum.Treble, stack: treble });
+	if (bass.length) voices.push({ staff: StaffEnum.Bass, stack: bass });
+	return { key, voices };
+};


### PR DESCRIPTION
## Summary
- add MIDI-driven `NotationInputScreen`
- create reusable `Select` component
- build notation with automatic rests using `notationBuilder`
- test rest generation logic

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684e6e8c5ee8832880f9d2590161cb22