### PR TITLE
Run MemoryFlashCore tests with yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "concurrently \"yarn workspace MemoryFlashServer dev\" \"yarn workspace MemoryFlashReact dev\"",
-		"test": "yarn workspace MemoryFlashServer test && yarn workspace MemoryFlashReact test:screenshots"
+		"test": "yarn workspace MemoryFlashServer test && yarn workspace MemoryFlashCore test && yarn workspace MemoryFlashReact test:screenshots"
 	},
 	"workspaces": [
 		"apps/*",

--- a/packages/MemoryFlashCore/package.json
+++ b/packages/MemoryFlashCore/package.json
@@ -4,10 +4,16 @@
 	"main": "index.js",
 	"license": "MIT",
 	"scripts": {
-		"build": "tsc"
+		"build": "tsc",
+		"test": "NODE_ENV=test mocha --timeout 10000 --require ts-node/register src/**/*.test.ts"
 	},
 	"devDependencies": {
+		"@types/chai": "^4.3.9",
+		"@types/mocha": "^10.0.3",
+		"chai": "^4.3.10",
 		"concurrently": "^9.0.1",
+		"mocha": "^10.2.0",
+		"ts-node": "^10.9.1",
 		"typescript": "^5.5.4"
 	},
 	"dependencies": {

--- a/packages/MemoryFlashCore/src/lib/measure.test.ts
+++ b/packages/MemoryFlashCore/src/lib/measure.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { insertRestsToFillBars } from 'MemoryFlashCore/src/lib/measure';
-import { StackedNotes } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { insertRestsToFillBars } from './measure';
+import { StackedNotes } from '../types/MultiSheetCard';
 
 describe('insertRestsToFillBars', () => {
 	it('adds rest to fill last bar', () => {

--- a/packages/MemoryFlashCore/tsconfig.json
+++ b/packages/MemoryFlashCore/tsconfig.json
@@ -7,7 +7,7 @@
 		"isolatedModules": true,
 		"jsx": "react-jsx",
 		"lib": ["dom", "dom.iterable", "esnext"],
-		"module": "esnext",
+		"module": "commonjs",
 		"moduleResolution": "node",
 		"noEmit": true,
 		"noUnusedLocals": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,12 +1917,17 @@ __metadata:
   resolution: "MemoryFlashCore@workspace:packages/MemoryFlashCore"
   dependencies:
     "@reduxjs/toolkit": "npm:^2.1.0"
+    "@types/chai": "npm:^4.3.9"
+    "@types/mocha": "npm:^10.0.3"
     "@types/react-redux": "npm:^7.1.33"
     axios: "npm:^1.7.4"
     bson-objectid: "npm:^2.0.4"
+    chai: "npm:^4.3.10"
     concurrently: "npm:^9.0.1"
+    mocha: "npm:^10.2.0"
     mongoose: "npm:^8.6.0"
     tonal: "npm:^6.2.0"
+    ts-node: "npm:^10.9.1"
     typescript: "npm:^5.5.4"
     zod: "npm:^3.22.4"
   languageName: unknown


### PR DESCRIPTION
## Summary
- run MemoryFlashCore tests from root `yarn test`
- support mocha testing in MemoryFlashCore
- fix imports in `measure.test.ts`
- use server-style test command and CommonJS module

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684f09cc97888328a91cc8fe9b510396