### PR TITLE
Enable runtime URL switching for iOS debug builds

### DIFF
--- a/apps/ios/MemoryFlashiOS/Constants.swift
+++ b/apps/ios/MemoryFlashiOS/Constants.swift
@@ -1,7 +1,17 @@
 import Foundation
 
+enum Server: String {
+    case development = "http://sd-mbpr.local:5173/"
+    case production = "https://mflash.riker.tech/"
+}
+
 #if DEBUG
-let WEB_APP_URL = "http://sd-mbpr.local:5173/"
+private let serverKey = "WEB_APP_SERVER"
+
+var WEB_APP_URL: String {
+    get { UserDefaults.standard.string(forKey: serverKey) ?? Server.development.rawValue }
+    set { UserDefaults.standard.set(newValue, forKey: serverKey) }
+}
 #else
-let WEB_APP_URL = "https://mflash.riker.tech/"
+let WEB_APP_URL = Server.production.rawValue
 #endif

--- a/apps/ios/MemoryFlashiOS/SettingsViewController.swift
+++ b/apps/ios/MemoryFlashiOS/SettingsViewController.swift
@@ -3,6 +3,10 @@ import CoreMIDI
 
 class SettingsViewController: UIViewController {
     var midiManager: MIDIManager?
+#if DEBUG
+    var serverLabel: UILabel?
+    var onServerChange: (() -> Void)?
+#endif
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,9 +41,15 @@ class SettingsViewController: UIViewController {
         stack.addArrangedSubview(versionLabel)
 
         #if DEBUG
-        let serverLabel = UILabel()
-        serverLabel.text = "Server: \(WEB_APP_URL)"
-        stack.addArrangedSubview(serverLabel)
+        let label = UILabel()
+        label.text = "Server: \(WEB_APP_URL)"
+        stack.addArrangedSubview(label)
+        serverLabel = label
+
+        let selector = UISegmentedControl(items: ["Dev", "Prod"])
+        selector.selectedSegmentIndex = WEB_APP_URL == Server.production.rawValue ? 1 : 0
+        selector.addTarget(self, action: #selector(changeServer), for: .valueChanged)
+        stack.addArrangedSubview(selector)
         #endif
 
         let midiButton = UIButton(type: .system)
@@ -57,4 +67,13 @@ class SettingsViewController: UIViewController {
             dismiss(animated: true, completion: nil)
         }
     }
+
+#if DEBUG
+    @objc func changeServer(_ sender: UISegmentedControl) {
+        let server: Server = sender.selectedSegmentIndex == 0 ? .development : .production
+        WEB_APP_URL = server.rawValue
+        serverLabel?.text = "Server: \(WEB_APP_URL)"
+        onServerChange?()
+    }
+#endif
 }

--- a/apps/ios/MemoryFlashiOS/ViewController.swift
+++ b/apps/ios/MemoryFlashiOS/ViewController.swift
@@ -75,6 +75,13 @@ class ViewController: UIViewController, WKScriptMessageHandler {
         
         self.webView = webView
     }
+
+    func reloadWebView() {
+        if let url = URL(string: WEB_APP_URL) {
+            let request = URLRequest(url: url)
+            webView?.load(request)
+        }
+    }
     
     func sendMIDIMessageToWebView(data: [UInt8]) {
         let dataString = data.map { String($0) }.joined(separator: ",")
@@ -97,6 +104,11 @@ class ViewController: UIViewController, WKScriptMessageHandler {
     @IBAction func openSettings(_ sender: Any) {
         let settingsVC = SettingsViewController()
         settingsVC.midiManager = midiManager
+#if DEBUG
+        settingsVC.onServerChange = { [weak self] in
+            self?.reloadWebView()
+        }
+#endif
         settingsVC.modalPresentationStyle = .formSheet
         present(settingsVC, animated: true, completion: nil)
     }


### PR DESCRIPTION
## Summary
- allow WEB_APP_URL to be changed at runtime when in debug
- expose dev/prod toggle in the iOS Settings screen
- reload the webview when the server changes

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684f10cfed6483288850f93a35b13d72