### PR TITLE
Add sign-up link to login page

### DIFF
--- a/apps/react/src/screens/LoginScreen.tsx
+++ b/apps/react/src/screens/LoginScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { login } from 'MemoryFlashCore/src/redux/actions/login-action';
 import { useAppDispatch } from 'MemoryFlashCore/src/redux/store';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
 import { useUpdateEffect } from '../utils/useUpdateEffect';
 import { AuthForm, EmailInput, InputField, Button } from '../components';
@@ -75,6 +75,15 @@ export const LoginScreen: React.FunctionComponent<{}> = ({}) => {
 			<Button type="submit" loading={isLoading}>
 				Login
 			</Button>
+			<p className="mt-6 text-center text-sm text-gray-500">
+				Not a member?{' '}
+				<Link
+					to="/auth/sign-up"
+					className="font-semibold text-blue-600 hover:text-blue-500"
+				>
+					Sign up
+				</Link>
+			</p>
 		</AuthForm>
 	);
 };

--- a/apps/react/src/screens/SignUpScreen.tsx
+++ b/apps/react/src/screens/SignUpScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { signUp } from 'MemoryFlashCore/src/redux/actions/sign-up-action';
 import { authSelector } from 'MemoryFlashCore/src/redux/selectors/authSelector';
 import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
@@ -84,6 +84,12 @@ export const SignUpScreen: React.FunctionComponent<{}> = ({}) => {
 			<Button type="submit" loading={isLoading}>
 				Sign Up
 			</Button>
+			<p className="mt-6 text-center text-sm text-gray-500">
+				Already have an account?{' '}
+				<Link to="/auth/login" className="font-semibold text-blue-600 hover:text-blue-500">
+					Log in
+				</Link>
+			</p>
 		</AuthForm>
 	);
 };


### PR DESCRIPTION
## Summary
- add a sign-up link at the bottom of the login form so new users can create an account
- add a login link at the bottom of the sign-up form for users that already have an account

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684f1d104c608328ad7aefc29e5c7247