### PR TITLE
Fix deck creation button

### DIFF
--- a/apps/react/src/screens/CoursesScreen.tsx
+++ b/apps/react/src/screens/CoursesScreen.tsx
@@ -1,11 +1,12 @@
 import { PresentationChartLineIcon } from '@heroicons/react/24/outline';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Layout, SectionData, SectionHeader } from '../components';
+import { Layout, SectionData, SectionHeader, Button } from '../components';
 import { CircleHover } from '../components/CircleHover';
 import { BasicErrorCard } from '../components/ErrorCard';
 import { MidiInputsDropdown } from '../components/MidiInputsDropdown';
 import { Spinner } from '../components/Spinner';
+import { Link } from 'react-router-dom';
 import { getCourses } from 'MemoryFlashCore/src/redux/actions/get-courses-action';
 import { coursesSelector } from 'MemoryFlashCore/src/redux/selectors/coursesSelector';
 import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
@@ -34,6 +35,11 @@ export const CoursesScreen = () => {
 						};
 					})}
 				/>
+				<div className="pt-4 flex justify-center">
+					<Link to="/course/create" className="w-48">
+						<Button>Create Course</Button>
+					</Link>
+				</div>
 			</div>
 		</Layout>
 	);

--- a/apps/react/src/screens/DecksScreen.tsx
+++ b/apps/react/src/screens/DecksScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
-import { Layout, SectionData, SectionHeader } from '../components';
+import { useParams, Link } from 'react-router-dom';
+import { Layout, SectionData, SectionHeader, Button } from '../components';
 import { BasicErrorCard } from '../components/ErrorCard';
 import { Spinner } from '../components/Spinner';
 import { getCourse } from 'MemoryFlashCore/src/redux/actions/get-course-action';
@@ -25,6 +25,7 @@ export const DecksScreen = () => {
 			parsingCourseId: state.courses.parsingCourse,
 		};
 	});
+	const userId = useAppSelector((state) => state.auth.user?._id);
 	const decks = useSelector(decksSelector);
 	const { isLoading, error } = useNetworkState('getCourse' + parsingCourseId);
 
@@ -61,6 +62,13 @@ export const DecksScreen = () => {
 					</div>
 				);
 			})}
+			{course && userId && course.userId === userId && (
+				<div className="pt-4 flex justify-center">
+					<Link to="/notation" className="w-48">
+						<Button>Create Deck</Button>
+					</Link>
+				</div>
+			)}
 		</Layout>
 	);
 };

--- a/packages/MemoryFlashCore/src/types/Course.ts
+++ b/packages/MemoryFlashCore/src/types/Course.ts
@@ -1,5 +1,6 @@
 export type Course = {
 	_id: string;
+	userId?: string;
 	name: string;
 	decks: string[];
 };


### PR DESCRIPTION
## Summary
- expose userId on Course types
- show Create Deck button for course owner and allow regardless of existing decks

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684f1dd653e88328a1e6b6b427112a2f