### PR TITLE
Fix server prod start

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
 		"dev": "nodemon src/app.ts",
 		"format": "prettier --write \"src/**/*.{ts,json}\"",
 		"lint": "eslint src/**/*.ts",
-		"start:prod": "ts-node --transpile-only src/app.ts",
+		"start:prod": "node dist/app.js",
 		"test": "NODE_ENV=test mocha --timeout 10000 --require ts-node/register --require dotenv/config src/**/*.test.ts",
 		"test:watch": "nodemon --ext ts --exec 'yarn test'"
 	},


### PR DESCRIPTION
## Summary
- fix `start:prod` script to run compiled JavaScript instead of ts-node

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684f25deac5083288e918885b172ad1f