### PR TITLE
Add password visibility toggle

### DIFF
--- a/apps/react/src/components/inputs/InputField.tsx
+++ b/apps/react/src/components/inputs/InputField.tsx
@@ -4,15 +4,27 @@ import { BaseInput, BaseInputProps } from './BaseInput';
 export interface InputFieldProps extends BaseInputProps {
 	label: string;
 	id: string;
+	afterElement?: React.ReactNode;
 }
 
-export const InputField: React.FC<InputFieldProps> = ({ label, id, ...props }) => (
+export const InputField: React.FC<InputFieldProps> = ({
+	label,
+	id,
+	afterElement,
+	className = '',
+	...props
+}) => (
 	<div>
 		<label htmlFor={id} className="block text-sm font-medium leading-6 text-gray-900">
 			{label}
 		</label>
-		<div className="mt-2">
-			<BaseInput id={id} {...props} />
+		<div className="mt-2 relative">
+			<BaseInput
+				id={id}
+				className={`${afterElement ? 'pr-10' : ''} ${className}`}
+				{...props}
+			/>
+			{afterElement}
 		</div>
 	</div>
 );

--- a/apps/react/src/components/inputs/PasswordInput.tsx
+++ b/apps/react/src/components/inputs/PasswordInput.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+import { InputField, InputFieldProps } from './InputField';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+
+export const PasswordInput: React.FC<Omit<InputFieldProps, 'type'>> = (props) => {
+	const [show, setShow] = useState(false);
+	return (
+		<InputField
+			{...props}
+			type={show ? 'text' : 'password'}
+			afterElement={
+				<button
+					type="button"
+					className="absolute inset-y-0 right-0 flex items-center pr-3"
+					onClick={() => setShow(!show)}
+				>
+					{show ? (
+						<EyeSlashIcon className="h-5 w-5 text-gray-500" />
+					) : (
+						<EyeIcon className="h-5 w-5 text-gray-500" />
+					)}
+				</button>
+			}
+		/>
+	);
+};

--- a/apps/react/src/components/inputs/index.ts
+++ b/apps/react/src/components/inputs/index.ts
@@ -1,4 +1,5 @@
 export * from './BaseInput';
 export * from './InputField';
 export * from './EmailInput';
+export * from './PasswordInput';
 export * from './Select';

--- a/apps/react/src/screens/LoginScreen.tsx
+++ b/apps/react/src/screens/LoginScreen.tsx
@@ -4,7 +4,7 @@ import { useAppDispatch } from 'MemoryFlashCore/src/redux/store';
 import { Link, useNavigate } from 'react-router-dom';
 import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
 import { useUpdateEffect } from '../utils/useUpdateEffect';
-import { AuthForm, EmailInput, InputField, Button } from '../components';
+import { AuthForm, EmailInput, PasswordInput, Button } from '../components';
 
 // Use:
 // https://tailwindui.com/components/application-ui/forms/sign-in-forms
@@ -39,10 +39,9 @@ export const LoginScreen: React.FunctionComponent<{}> = ({}) => {
 				required
 			/>
 
-			<InputField
+			<PasswordInput
 				id="password"
 				label="Password"
-				type="password"
 				value={password}
 				onChange={(e) => setPassword(e.target.value)}
 				required

--- a/apps/react/src/screens/SignUpScreen.tsx
+++ b/apps/react/src/screens/SignUpScreen.tsx
@@ -4,7 +4,7 @@ import { signUp } from 'MemoryFlashCore/src/redux/actions/sign-up-action';
 import { authSelector } from 'MemoryFlashCore/src/redux/selectors/authSelector';
 import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
 import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
-import { AuthForm, EmailInput, InputField, Button } from '../components';
+import { AuthForm, EmailInput, PasswordInput, InputField, Button } from '../components';
 
 export const SignUpScreen: React.FunctionComponent<{}> = ({}) => {
 	const dispatch = useAppDispatch();
@@ -47,10 +47,9 @@ export const SignUpScreen: React.FunctionComponent<{}> = ({}) => {
 				required
 			/>
 
-			<InputField
+			<PasswordInput
 				id="password"
 				label="Password"
-				type="password"
 				value={password}
 				onChange={(e) => setPassword(e.target.value)}
 				required


### PR DESCRIPTION
## Summary
- enhance `InputField` to support trailing elements like a visibility toggle
- add new `PasswordInput` component using the base `InputField`
- use `PasswordInput` on Login and Sign Up screens

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684fab6e62f88328a5677d51ca626c00