### PR TITLE
Define NoteDuration type

### DIFF
--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Layout } from '../components';
 import { MusicNotation } from '../components/MusicNotation';
-import { StackedNotes } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StackedNotes, NoteDuration } from 'MemoryFlashCore/src/types/MultiSheetCard';
 import { majorKeys } from 'MemoryFlashCore/src/lib/notes';
 import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
 import { MusicRecorder } from 'MemoryFlashCore/src/lib/MusicRecorder';
@@ -10,8 +10,8 @@ import { Select } from '../components/inputs';
 const NoteSettings: React.FC<{
 	keySig: string;
 	setKeySig: (k: string) => void;
-	dur: StackedNotes['duration'];
-	setDur: (d: StackedNotes['duration']) => void;
+	dur: NoteDuration;
+	setDur: (d: NoteDuration) => void;
 }> = ({ keySig, setKeySig, dur, setDur }) => (
 	<div className="flex gap-4 pb-4">
 		<label className="flex items-center gap-2">
@@ -24,10 +24,7 @@ const NoteSettings: React.FC<{
 		</label>
 		<label className="flex items-center gap-2">
 			Duration
-			<Select
-				value={dur}
-				onChange={(e) => setDur(e.target.value as StackedNotes['duration'])}
-			>
+			<Select value={dur} onChange={(e) => setDur(e.target.value as NoteDuration)}>
 				{['w', 'h', 'q', '8', '16'].map((d) => (
 					<option key={d} value={d}>
 						{d}
@@ -41,7 +38,7 @@ const NoteSettings: React.FC<{
 export const NotationInputScreen = () => {
 	const [notes, setNotes] = useState<StackedNotes[]>([]);
 	const [keySig, setKeySig] = useState(majorKeys[0]);
-	const [dur, setDur] = useState<StackedNotes['duration']>('q');
+	const [dur, setDur] = useState<NoteDuration>('q');
 
 	const recorderRef = useRef(new MusicRecorder('q'));
 	const midiNotes = useAppSelector((state) => state.midi.notes.map((n) => n.number));

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -1,5 +1,5 @@
 import { Midi } from 'tonal';
-import { MultiSheetQuestion, StackedNotes } from '../types/MultiSheetCard';
+import { MultiSheetQuestion, StackedNotes, NoteDuration } from '../types/MultiSheetCard';
 import { StaffEnum } from '../types/Cards';
 import { insertRestsToFillBars } from './measure';
 import { buildMultiSheetQuestion } from './notationBuilder';
@@ -8,9 +8,9 @@ export class MusicRecorder {
 	public notes: StackedNotes[] = [];
 	private prevMidiNotes: number[] = [];
 
-	constructor(public duration: StackedNotes['duration'] = 'q') {}
+	constructor(public duration: NoteDuration = 'q') {}
 
-	updateDuration(dur: StackedNotes['duration']) {
+	updateDuration(dur: NoteDuration) {
 		this.duration = dur;
 	}
 

--- a/packages/MemoryFlashCore/src/types/MultiSheetCard.ts
+++ b/packages/MemoryFlashCore/src/types/MultiSheetCard.ts
@@ -14,6 +14,8 @@ export type StackedNotes = {
 	chordName?: string;
 	rest?: boolean;
 };
+
+export type NoteDuration = StackedNotes['duration'];
 export type MultiSheetQuestion = {
 	_8va?: boolean;
 	key: string;


### PR DESCRIPTION
## Summary
- add `NoteDuration` type alias for the duration union
- use `NoteDuration` in NotationInputScreen and MusicRecorder

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684facd6aaf88328bbabaae335ae6a8c