### PR TITLE
Fix screenshot test and infinite loop

### DIFF
--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { shallowEqual } from 'react-redux';
 import { Layout } from '../components';
 import { MusicNotation } from '../components/MusicNotation';
 import { StackedNotes, NoteDuration } from 'MemoryFlashCore/src/types/MultiSheetCard';
@@ -41,7 +42,10 @@ export const NotationInputScreen = () => {
 	const [dur, setDur] = useState<NoteDuration>('q');
 
 	const recorderRef = useRef(new MusicRecorder('q'));
-	const midiNotes = useAppSelector((state) => state.midi.notes.map((n) => n.number));
+	const midiNotes = useAppSelector(
+		(state) => state.midi.notes.map((n) => n.number),
+		shallowEqual,
+	);
 
 	useEffect(() => {
 		recorderRef.current.updateDuration(dur);

--- a/apps/react/tests/notation-input-screen.spec.ts
+++ b/apps/react/tests/notation-input-screen.spec.ts
@@ -4,8 +4,17 @@ import fs from 'fs';
 import path from 'path';
 
 test('NotationInputScreen renders with whole rest', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(msg.text());
+	});
+
 	await page.goto('/tests/notation-input-screen-test.html');
 	const output = page.locator('#root');
 	await output.waitFor();
+	await page.waitForTimeout(200);
+
+	expect(errors).toEqual([]);
 	await expect(output).toHaveScreenshot('notation-input-screen.png', screenshotOpts);
 });


### PR DESCRIPTION
## Summary
- fix infinite render loop in NotationInputScreen by stabilizing midi note selector
- check console errors in the NotationInputScreen screenshot test

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684fc1b5dd0c8328a718129befc91b3d