### PR TITLE
Fix Select component visibility in dark mode

### DIFF
--- a/apps/react/src/components/inputs/Select.tsx
+++ b/apps/react/src/components/inputs/Select.tsx
@@ -4,7 +4,11 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
 
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
 	({ className = '', children, ...props }, ref) => (
-		<select ref={ref} className={`form-select rounded ${className}`} {...props}>
+		<select
+			ref={ref}
+			className={`block w-full rounded-md border-0 py-1.5 bg-white dark:bg-gray-800 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 ${className}`}
+			{...props}
+		>
 			{children}
 		</select>
 	),


### PR DESCRIPTION
## Summary
- make Select component match BaseInput styling so text is visible in dark mode

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684fc8a6ce2483289a77b21cb29a56aa