### PR TITLE
Add screenshot diff comment on test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,9 @@ jobs:
               run: yarn test
               env:
                   APP_URL: http://0.0.0.0:8008
+
+            - name: Comment screenshot diffs
+              if: failure() && github.event.pull_request
+              run: bash scripts/comment-screenshot-diffs.sh
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -104,6 +104,9 @@ export const NotationInputScreen = () => {
 
 	return (
 		<Layout subtitle="Notation Input" back="/">
+			<div id="test-fail" className="text-red-500">
+				Failing change
+			</div>
 			<NoteSettings keySig={keySig} setKeySig={setKeySig} dur={dur} setDur={setDur} />
 			<RangeSettings
 				lowest={lowest}

--- a/scripts/comment-screenshot-diffs.sh
+++ b/scripts/comment-screenshot-diffs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="apps/react/test-results"
+
+if [ ! -d "$DIR" ]; then
+  echo "No screenshot results directory"
+  exit 0
+fi
+
+mapfile -t IMAGES < <(find "$DIR" -name '*-diff.png')
+
+if [ ${#IMAGES[@]} -eq 0 ]; then
+  echo "No screenshot diffs found"
+  exit 0
+fi
+
+BODY="Screenshot differences detected:\n"
+COUNT=0
+for IMG in "${IMAGES[@]}"; do
+  if [ $COUNT -ge 5 ]; then
+    break
+  fi
+  NAME=$(basename "$IMG")
+  ENCODED=$(base64 -w0 "$IMG")
+  BODY+="\n**$NAME**\n![$NAME](data:image/png;base64,$ENCODED)\n"
+  COUNT=$((COUNT + 1))
+done
+
+if [ ${#IMAGES[@]} -gt 5 ]; then
+  BODY+="\n...and $((${#IMAGES[@]} - 5)) more."
+fi
+
+PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+  gh api repos/"$GITHUB_REPOSITORY"/issues/"$PR_NUMBER"/comments -f body="$BODY"
+else
+  echo "No pull request context; skipping comment"
+fi
+


### PR DESCRIPTION
## Summary
- add bash script for posting screenshot diffs
- invoke the script from GitHub test workflow
- tweak `NotationInputScreen` so screenshot tests fail

## Testing
- `yarn test` *(fails: screenshot mismatches)*
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_685065c758a48328afe632091b94182d