### PR TITLE
Fix notation overflow handling

### DIFF
--- a/apps/react/tests/notation-input-overflow.spec.ts
+++ b/apps/react/tests/notation-input-overflow.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+// Regression test for measure overflow crash being fixed
+
+test('NotationInputScreen handles overflow input', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(msg.text());
+	});
+
+	await page.goto('/tests/notation-input-screen-test.html');
+	await page.locator('#root').waitFor();
+
+	const press = async (midi: number) => {
+		await page.evaluate((n) => {
+			(window as any).store.dispatch({ type: 'midi/addNote', payload: n });
+		}, midi);
+		await page.evaluate((n) => {
+			(window as any).store.dispatch({ type: 'midi/removeNote', payload: n });
+		}, midi);
+	};
+
+	for (const m of [60, 62, 64, 65]) {
+		await press(m);
+	}
+	errors.length = 0;
+	await press(67);
+	await page.waitForTimeout(100);
+
+	expect(errors).toEqual([]);
+});

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
@@ -34,4 +34,12 @@ describe('MusicRecorder', () => {
 		const r = new MusicRecorder('q');
 		expect(r.filledNotes).to.deep.equal([{ notes: [], duration: 'w', rest: true }]);
 	});
+
+	it('ignores notes beyond one measure', () => {
+		const r = new MusicRecorder('q');
+		for (const n of [60, 62, 64, 65, 67]) {
+			r.addMidiNotes([n]);
+		}
+		expect(r.notes.length).to.equal(4);
+	});
 });

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -1,7 +1,7 @@
 import { Midi } from 'tonal';
 import { MultiSheetQuestion, StackedNotes, NoteDuration } from '../types/MultiSheetCard';
 import { StaffEnum } from '../types/Cards';
-import { insertRestsToFillBars } from './measure';
+import { insertRestsToFillBars, durationBeats } from './measure';
 import { buildMultiSheetQuestion } from './notationBuilder';
 
 export class MusicRecorder {
@@ -17,12 +17,16 @@ export class MusicRecorder {
 	addMidiNotes(midiNotes: number[]): void {
 		const added = midiNotes.filter((m) => !this.prevMidiNotes.includes(m));
 		if (added.length) {
-			const sheetNotes = added.map((m) => {
-				const name = Midi.midiToNoteName(m);
-				const match = name.match(/([A-G][#b]?)(\d+)/)!;
-				return { name: match[1], octave: parseInt(match[2]) };
-			});
-			this.notes.push({ notes: sheetNotes, duration: this.duration });
+			const currentBeats = this.notes.reduce((sum, n) => sum + durationBeats[n.duration], 0);
+			const nextBeats = currentBeats + durationBeats[this.duration];
+			if (nextBeats <= 4) {
+				const sheetNotes = added.map((m) => {
+					const name = Midi.midiToNoteName(m);
+					const match = name.match(/([A-G][#b]?)(\d+)/)!;
+					return { name: match[1], octave: parseInt(match[2]) };
+				});
+				this.notes.push({ notes: sheetNotes, duration: this.duration });
+			}
 		}
 		this.prevMidiNotes = midiNotes;
 	}


### PR DESCRIPTION
## Summary
- limit MusicRecorder to one measure
- update overflow regression test
- cover overflow case in unit tests

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684fc8fe1e4c83289a6ec10acf316929