### PR TITLE
Fix CI status check visibility

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
     prettier:
+        name: Prettier
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
     test:
+        name: Test
         runs-on: ubuntu-latest
 
         strategy:


### PR DESCRIPTION
## Summary
- add job names to prettier and test workflows so GitHub can list them as status checks

## Testing
- `yarn test` *(fails: music notation screenshot tests fail)*
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_6850e7416f8c8328bbd3970b886b7f16