### PR TITLE
Fix MusicRecorder test overflow

### DIFF
--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -1,12 +1,13 @@
 import { Midi } from 'tonal';
 import { MultiSheetQuestion, StackedNotes, NoteDuration } from '../types/MultiSheetCard';
 import { StaffEnum } from '../types/Cards';
-import { insertRestsToFillBars } from './measure';
+import { insertRestsToFillBars, durationBeats } from './measure';
 import { buildMultiSheetQuestion } from './notationBuilder';
 
 export class MusicRecorder {
 	public notes: StackedNotes[] = [];
 	private prevMidiNotes: number[] = [];
+	private beatsPerBar = 4;
 
 	constructor(public duration: NoteDuration = 'q') {}
 
@@ -17,6 +18,12 @@ export class MusicRecorder {
 	addMidiNotes(midiNotes: number[]): void {
 		const added = midiNotes.filter((m) => !this.prevMidiNotes.includes(m));
 		if (added.length) {
+			const beatsSoFar = this.notes.reduce((sum, n) => sum + durationBeats[n.duration], 0);
+			const beats = durationBeats[this.duration];
+			if (beatsSoFar + beats > this.beatsPerBar) {
+				this.prevMidiNotes = midiNotes;
+				return;
+			}
 			const sheetNotes = added.map((m) => {
 				const name = Midi.midiToNoteName(m);
 				const match = name.match(/([A-G][#b]?)(\d+)/)!;

--- a/packages/MemoryFlashCore/src/lib/notationBuilder.ts
+++ b/packages/MemoryFlashCore/src/lib/notationBuilder.ts
@@ -1,16 +1,24 @@
 import { StaffEnum } from '../types/Cards';
 import { MultiSheetQuestion, StackedNotes, Voice } from '../types/MultiSheetCard';
+import { insertRestsToFillBars } from './measure';
 
 export function buildMultiSheetQuestion(notes: StackedNotes[], key: string): MultiSheetQuestion {
 	const treble: StackedNotes[] = [];
 	const bass: StackedNotes[] = [];
 	for (const n of notes) {
-		const octave = n.notes[0]?.octave ?? 0;
+		if (n.notes.length === 0) {
+			if (treble.length || (!treble.length && !bass.length)) treble.push(n);
+			if (bass.length) bass.push(n);
+			continue;
+		}
+		const octave = n.notes[0].octave;
 		if (octave >= 4) treble.push(n);
 		else bass.push(n);
 	}
+
 	const voices: Voice[] = [];
-	if (treble.length) voices.push({ staff: StaffEnum.Treble, stack: treble });
-	if (bass.length) voices.push({ staff: StaffEnum.Bass, stack: bass });
+	if (treble.length)
+		voices.push({ staff: StaffEnum.Treble, stack: insertRestsToFillBars(treble) });
+	if (bass.length) voices.push({ staff: StaffEnum.Bass, stack: insertRestsToFillBars(bass) });
 	return { key, voices };
 }


### PR DESCRIPTION
## Summary
- restrict MusicRecorder to one measure
- keep rests with appropriate voice in notationBuilder

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_6850fe5b899083288921fc5d9109b41a