### PR TITLE
Add notation screen button for custom decks

### DIFF
--- a/apps/react/src/App.tsx
+++ b/apps/react/src/App.tsx
@@ -36,7 +36,10 @@ export default function App() {
 						path="/account"
 						element={<AuthenticatedRoute screen={<AccountScreen />} />}
 					/>
-					<Route path="/notation" element={<NotationInputScreen />} />
+					<Route
+						path="/study/:deckId/notation"
+						element={<AuthenticatedRoute screen={<NotationInputScreen />} />}
+					/>
 					<Route
 						path="/course/:courseId"
 						element={<AuthenticatedRoute screen={<DecksScreen />} />}

--- a/apps/react/src/screens/DecksScreen.tsx
+++ b/apps/react/src/screens/DecksScreen.tsx
@@ -77,8 +77,11 @@ export const DecksScreen = () => {
 						onClose={() => setIsCreateOpen(false)}
 						label="Deck name"
 						onSave={(val) => {
-							dispatch(createDeck(course._id, val));
-							navigate('/notation');
+							dispatch(
+								createDeck(course._id, val, {
+									successCb: (deck) => navigate(`/study/${deck._id}/notation`),
+								}),
+							);
 						}}
 					/>
 				</>

--- a/apps/react/src/screens/StudyScreen/StudyScreen.tsx
+++ b/apps/react/src/screens/StudyScreen/StudyScreen.tsx
@@ -1,4 +1,4 @@
-import { ListBulletIcon, PresentationChartLineIcon } from '@heroicons/react/24/outline';
+import { ListBulletIcon, PresentationChartLineIcon, PlusIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { CircleHover } from '../../components/CircleHover';
@@ -44,6 +44,7 @@ export const StudyScreen = () => {
 	const course = useAppSelector((state) =>
 		deck?.courseId ? state.courses.entities[deck.courseId] : undefined,
 	);
+	const user = useAppSelector((state) => state.auth.user);
 
 	const timeSinceCardStart = () => (currStartTime > 0 ? (Date.now() - currStartTime) / 1000 : 0);
 
@@ -137,6 +138,11 @@ export const StudyScreen = () => {
 					<CircleHover link={`list`}>
 						<ListBulletIcon className="w-6 h-6 stroke-2" />
 					</CircleHover>
+					{course && user && course.userId === user._id && (
+						<CircleHover link={`/study/${deckId}/notation`}>
+							<PlusIcon className="w-6 h-6 stroke-2" />
+						</CircleHover>
+					)}
 					<MidiInputsDropdown />
 					<AccountNavButton />
 				</div>

--- a/packages/MemoryFlashCore/src/redux/actions/create-deck-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/create-deck-action.ts
@@ -1,12 +1,14 @@
 import { decksActions } from '../slices/decksSlice';
 import { AppThunk } from '../store';
 import { networkCallWithReduxState } from '../util/networkStateHelper';
+import { Deck } from '../../types/Deck';
 
 export const createDeck =
-	(courseId: string, name: string): AppThunk =>
+	(courseId: string, name: string, options?: { successCb?: (deck: Deck) => void }): AppThunk =>
 	async (dispatch, _, { api }) => {
 		await networkCallWithReduxState(dispatch, 'createDeck', async () => {
 			const res = await api.post('/decks', { courseId, name });
 			dispatch(decksActions.upsert([res.data.deck]));
+			options?.successCb?.(res.data.deck);
 		});
 	};


### PR DESCRIPTION
## Summary
- expose notation route for specific decks
- show a notation button on StudyScreen when viewing your own deck
- return created deck to callback so DecksScreen can navigate

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test` *(fails: MusicRecorder ignores notes beyond one measure)*

------
https://chatgpt.com/codex/tasks/task_e_685105ffaa8c8328b3f86b30b629a4fa