### PR TITLE
Add iOS debug reload control

### DIFF
--- a/apps/ios/MemoryFlashiOS/ViewController.swift
+++ b/apps/ios/MemoryFlashiOS/ViewController.swift
@@ -35,6 +35,14 @@ class ViewController: UIViewController, WKScriptMessageHandler {
         contentController.add(self, name: "midiHandler")
         contentController.add(self, name: "consoleHandler")
         contentController.add(self, name: "openSettings")
+#if DEBUG
+        let debugScript = WKUserScript(
+            source: "window.iosDebug = true;",
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        )
+        contentController.addUserScript(debugScript)
+#endif
 
         // Disable pinch to zoom & read console log messages
         if let disablePinchToZoomPath = Bundle.main.path(forResource: "Setup", ofType: "js"),

--- a/apps/react/src/components/Layout.tsx
+++ b/apps/react/src/components/Layout.tsx
@@ -1,10 +1,11 @@
-import { ChevronLeftIcon } from '@heroicons/react/24/outline';
+import { ChevronLeftIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CircleHover } from './CircleHover';
 import { MidiInputsDropdown } from './MidiInputsDropdown';
 import { AccountNavButton } from './navigation/AccountNavButton';
+import { isIOSDebug } from '../utils/isIOSDebug';
 
 interface LayoutProps {
 	children: React.ReactNode;
@@ -25,6 +26,13 @@ export const Layout: React.FC<LayoutProps> = ({
 }) => {
 	const navigate = useNavigate();
 	const location = useLocation();
+	const iosDebug = isIOSDebug();
+	const rightContent = right || (
+		<>
+			<AccountNavButton />
+			<MidiInputsDropdown />
+		</>
+	);
 
 	return (
 		<div className="mx-auto h-screen w-full flex flex-col overflow-scroll " onScroll={onScroll}>
@@ -48,11 +56,11 @@ export const Layout: React.FC<LayoutProps> = ({
 					<span className="text-xs">{subtitle}</span>
 				</div>
 				<div className="flex flex-row-reverse items-center gap-3">
-					{right || (
-						<>
-							<AccountNavButton />
-							<MidiInputsDropdown />
-						</>
+					{rightContent}
+					{iosDebug && (
+						<CircleHover onClick={() => window.location.reload()}>
+							<ArrowPathIcon className="w-6 h-6 stroke-2" />
+						</CircleHover>
 					)}
 				</div>
 			</div>

--- a/apps/react/src/utils/isIOSDebug.ts
+++ b/apps/react/src/utils/isIOSDebug.ts
@@ -1,0 +1,1 @@
+export const isIOSDebug = (): boolean => Boolean((window as any).iosDebug);


### PR DESCRIPTION
## Summary
- inject `iosDebug` flag for DEBUG builds in ViewController
- show reload icon in Layout on all pages when `iosDebug` is true
- add helper to detect iOS debug builds

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_684fc83d86708328a4d13a7efd601021