### PR TITLE
Add rename/delete permissions checks

### DIFF
--- a/apps/react/src/components/CardOptionsMenu.tsx
+++ b/apps/react/src/components/CardOptionsMenu.tsx
@@ -1,0 +1,65 @@
+import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+import Dropdown from './Dropdown';
+import { InputModal } from './modals/InputModal';
+import { ConfirmModal } from './modals/ConfirmModal';
+
+interface CardOptionsMenuProps {
+	itemName?: string;
+	onRename: (name: string) => void;
+	onDelete: () => void;
+	renameLabel?: string;
+	confirmMessage?: string;
+}
+
+export const CardOptionsMenu: React.FC<CardOptionsMenuProps> = ({
+	itemName,
+	onRename,
+	onDelete,
+	renameLabel = 'Name',
+	confirmMessage = 'Are you sure?',
+}) => {
+	const [isRenameOpen, setIsRenameOpen] = React.useState(false);
+	const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
+
+	return (
+		<>
+			<Dropdown
+				label={<EllipsisVerticalIcon className="w-5 h-5" />}
+				items={[
+					{
+						label: 'Rename',
+						onClick: () => {
+							if (itemName !== undefined) setIsRenameOpen(true);
+							else onRename('');
+						},
+					},
+					{
+						label: 'Delete',
+						onClick: () => {
+							if (itemName !== undefined) setIsDeleteOpen(true);
+							else onDelete();
+						},
+					},
+				]}
+			/>
+			{itemName !== undefined && (
+				<>
+					<InputModal
+						isOpen={isRenameOpen}
+						onClose={() => setIsRenameOpen(false)}
+						label={renameLabel}
+						value={itemName}
+						onSave={(val) => onRename(val)}
+					/>
+					<ConfirmModal
+						isOpen={isDeleteOpen}
+						onClose={() => setIsDeleteOpen(false)}
+						message={confirmMessage}
+						onConfirm={onDelete}
+					/>
+				</>
+			)}
+		</>
+	);
+};

--- a/apps/react/src/components/Dropdown.tsx
+++ b/apps/react/src/components/Dropdown.tsx
@@ -8,7 +8,7 @@ interface DropdownItem {
 }
 
 interface DropdownProps {
-	label: string;
+	label: React.ReactNode;
 	items: DropdownItem[];
 	onButtonClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined) => void;
 }

--- a/apps/react/src/components/SectionCard.tsx
+++ b/apps/react/src/components/SectionCard.tsx
@@ -8,6 +8,7 @@ interface SectionCardProps {
 	link: string;
 	btnText: string;
 	className?: string;
+	menu?: React.ReactNode;
 }
 
 export const SectionCard: React.FC<SectionCardProps> = ({
@@ -16,12 +17,14 @@ export const SectionCard: React.FC<SectionCardProps> = ({
 	className,
 	subTitle,
 	link,
+	menu,
 }) => {
 	return (
 		<Card
 			className={`w-44 h-44 ${className}`}
-			contentContainerClassName="justify-between items-center"
+			contentContainerClassName="justify-between items-center relative"
 		>
+			{menu && <div className="absolute top-2 right-2">{menu}</div>}
 			<div className="text-center">
 				<div className="text-sm font-medium">{title}</div>
 				{subTitle && <div className="text-[0.6rem]">{subTitle}</div>}

--- a/apps/react/src/components/SectionData.tsx
+++ b/apps/react/src/components/SectionData.tsx
@@ -5,6 +5,7 @@ export const SectionData: React.FC<{
 		title: string;
 		subTitle?: string;
 		link: string;
+		menu?: React.ReactNode;
 	}[];
 	btnText: string;
 }> = ({ items, btnText }) => {
@@ -17,6 +18,7 @@ export const SectionData: React.FC<{
 					subTitle={item.subTitle}
 					link={item.link}
 					btnText={btnText}
+					menu={item.menu}
 				/>
 			))}
 		</div>

--- a/apps/react/src/components/index.ts
+++ b/apps/react/src/components/index.ts
@@ -11,3 +11,5 @@ export * from './inputs';
 export * from './Button';
 export * from './modals/Modal';
 export * from './modals/InputModal';
+export * from './modals/ConfirmModal';
+export * from './CardOptionsMenu';

--- a/apps/react/src/components/modals/ConfirmModal.tsx
+++ b/apps/react/src/components/modals/ConfirmModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+
+export interface ConfirmModalProps extends Omit<ModalProps, 'children' | 'title'> {
+	message: string;
+	confirmText?: string;
+	onConfirm: () => void;
+	title?: string;
+}
+
+export const ConfirmModal: React.FC<ConfirmModalProps> = ({
+	isOpen,
+	onClose,
+	message,
+	confirmText = 'Delete',
+	onConfirm,
+	title,
+}) => (
+	<Modal isOpen={isOpen} onClose={onClose} title={title}>
+		<div className="px-6">
+			<div className="mt-3 mb-6 text-center sm:mt-0 sm:text-left">{message}</div>
+		</div>
+		<div className="mt-8  sm:flex sm:pl-4 gap-3 justify-end bg-gray-50 px-6 pt-3 pb-4 border-t border-gray-100">
+			<button
+				type="button"
+				data-autofocus
+				onClick={onClose}
+				className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto mb-3 sm:mb-0"
+			>
+				Cancel
+			</button>
+			<button
+				type="button"
+				onClick={() => {
+					onConfirm();
+					onClose();
+				}}
+				className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:w-auto"
+			>
+				{confirmText}
+			</button>
+		</div>
+	</Modal>
+);

--- a/apps/react/src/screens/CoursesScreen.tsx
+++ b/apps/react/src/screens/CoursesScreen.tsx
@@ -1,22 +1,35 @@
 import { PresentationChartLineIcon } from '@heroicons/react/24/outline';
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Layout, SectionData, SectionHeader, Button, InputModal } from '../components';
+import {
+	Layout,
+	SectionData,
+	SectionHeader,
+	Button,
+	InputModal,
+	CardOptionsMenu,
+	ConfirmModal,
+} from '../components';
 import { CircleHover } from '../components/CircleHover';
 import { BasicErrorCard } from '../components/ErrorCard';
 import { MidiInputsDropdown } from '../components/MidiInputsDropdown';
 import { Spinner } from '../components/Spinner';
 import { getCourses } from 'MemoryFlashCore/src/redux/actions/get-courses-action';
 import { createCourse } from 'MemoryFlashCore/src/redux/actions/create-course-action';
+import { renameCourse } from 'MemoryFlashCore/src/redux/actions/rename-course-action';
 import { coursesSelector } from 'MemoryFlashCore/src/redux/selectors/coursesSelector';
 import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
-import { useAppDispatch } from 'MemoryFlashCore/src/redux/store';
+import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
+import { deleteCourse } from 'MemoryFlashCore/src/redux/actions/delete-course-action';
 
 export const CoursesScreen = () => {
 	const dispatch = useAppDispatch();
 	const courses = useSelector(coursesSelector);
+	const user = useAppSelector((state) => state.auth.user);
 	const { isLoading, error } = useNetworkState('getCourses');
 	const [isCreateOpen, setIsCreateOpen] = React.useState(false);
+	const [renameCourseId, setRenameCourseId] = React.useState<string | undefined>();
+	const [deleteCourseId, setDeleteCourseId] = React.useState<string | undefined>();
 	useEffect(() => {
 		dispatch(getCourses());
 	}, []);
@@ -33,6 +46,13 @@ export const CoursesScreen = () => {
 						return {
 							title: course.name,
 							link: `/course/${course._id}`,
+							menu:
+								user && course.userId === user._id ? (
+									<CardOptionsMenu
+										onRename={() => setRenameCourseId(course._id)}
+										onDelete={() => setDeleteCourseId(course._id)}
+									/>
+								) : undefined,
 						};
 					})}
 				/>
@@ -46,6 +66,21 @@ export const CoursesScreen = () => {
 					onClose={() => setIsCreateOpen(false)}
 					label="Course name"
 					onSave={(val) => dispatch(createCourse(val))}
+				/>
+				<InputModal
+					isOpen={!!renameCourseId}
+					onClose={() => setRenameCourseId(undefined)}
+					label="Course name"
+					value={courses.find((c) => c._id === renameCourseId)?.name}
+					onSave={(val) => renameCourseId && dispatch(renameCourse(renameCourseId, val))}
+				/>
+				<ConfirmModal
+					isOpen={!!deleteCourseId}
+					onClose={() => setDeleteCourseId(undefined)}
+					message="Are you sure you want to delete this course?"
+					onConfirm={() => {
+						if (deleteCourseId) dispatch(deleteCourse(deleteCourseId));
+					}}
 				/>
 			</div>
 		</Layout>

--- a/apps/react/src/screens/DecksScreen.tsx
+++ b/apps/react/src/screens/DecksScreen.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { useParams, Link, useNavigate } from 'react-router-dom';
-import { Layout, SectionData, SectionHeader, Button, InputModal } from '../components';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+	Layout,
+	SectionData,
+	SectionHeader,
+	Button,
+	InputModal,
+	CardOptionsMenu,
+} from '../components';
 import { BasicErrorCard } from '../components/ErrorCard';
 import { Spinner } from '../components/Spinner';
 import { getCourse } from 'MemoryFlashCore/src/redux/actions/get-course-action';
@@ -9,6 +16,8 @@ import { decksSelector } from 'MemoryFlashCore/src/redux/selectors/decksSelector
 import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
 import { coursesActions } from 'MemoryFlashCore/src/redux/slices/coursesSlice';
 import { createDeck } from 'MemoryFlashCore/src/redux/actions/create-deck-action';
+import { renameDeck } from 'MemoryFlashCore/src/redux/actions/rename-deck-action';
+import { deleteDeck } from 'MemoryFlashCore/src/redux/actions/delete-deck-action';
 import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
 
 export const DecksScreen = () => {
@@ -59,6 +68,20 @@ export const DecksScreen = () => {
 									subTitle:
 										deck.stats &&
 										`Median: ${deck.stats?.medianTimeTaken.toFixed(1)}`,
+									menu:
+										course && user && course.userId === user._id ? (
+											<CardOptionsMenu
+												itemName={deck.name}
+												renameLabel="Deck name"
+												confirmMessage="Are you sure you want to delete this deck?"
+												onRename={(val) =>
+													dispatch(renameDeck(String(deck._id), val))
+												}
+												onDelete={() =>
+													dispatch(deleteDeck(String(deck._id)))
+												}
+											/>
+										) : undefined,
 								};
 							})}
 						/>

--- a/apps/server/src/routes/coursesRouter.ts
+++ b/apps/server/src/routes/coursesRouter.ts
@@ -1,6 +1,12 @@
 import { Router } from 'express';
 import { isAuthenticated } from '../middleware';
-import { getCourses, getDecksForCourse, createCourse } from '../services/coursesService';
+import {
+	getCourses,
+	getDecksForCourse,
+	createCourse,
+	renameCourse,
+	deleteCourse,
+} from '../services/coursesService';
 import { User } from 'MemoryFlashCore/src/types/User';
 
 const router = Router();
@@ -36,6 +42,28 @@ router.get('/:id', isAuthenticated, async (req, res, next) => {
 			course,
 			userDeckStats,
 		});
+	} catch (error) {
+		next(error);
+	}
+});
+
+router.patch('/:id', isAuthenticated, async (req, res, next) => {
+	try {
+		const course = await renameCourse(
+			req.params.id,
+			req.body.name,
+			(req.user as User)._id.toString(),
+		);
+		return res.json({ course });
+	} catch (error) {
+		next(error);
+	}
+});
+
+router.delete('/:id', isAuthenticated, async (req, res, next) => {
+	try {
+		await deleteCourse(req.params.id, (req.user as User)._id.toString());
+		return res.json({});
 	} catch (error) {
 		next(error);
 	}

--- a/apps/server/src/routes/decksRouter.ts
+++ b/apps/server/src/routes/decksRouter.ts
@@ -1,6 +1,12 @@
 import { Router } from 'express';
 import { isAuthenticated } from '../middleware';
-import { getDeckForUser, createDeck, addCardsToDeck } from '../services/deckService';
+import {
+	getDeckForUser,
+	createDeck,
+	addCardsToDeck,
+	renameDeck,
+	deleteDeckById,
+} from '../services/deckService';
 import { User } from 'MemoryFlashCore/src/types/User';
 import { getDeckStats } from '../services/statsService';
 
@@ -53,6 +59,28 @@ router.post('/:id/cards', isAuthenticated, async (req, res, next) => {
 		const { questions } = req.body;
 		const cards = await addCardsToDeck(req.params.id, questions);
 		return res.json({ cards });
+	} catch (error) {
+		next(error);
+	}
+});
+
+router.patch('/:id', isAuthenticated, async (req, res, next) => {
+	try {
+		const deck = await renameDeck(
+			req.params.id,
+			req.body.name,
+			(req.user as User)._id.toString(),
+		);
+		return res.json({ deck });
+	} catch (error) {
+		next(error);
+	}
+});
+
+router.delete('/:id', isAuthenticated, async (req, res, next) => {
+	try {
+		await deleteDeckById(req.params.id, (req.user as User)._id.toString());
+		return res.json({});
 	} catch (error) {
 		next(error);
 	}

--- a/apps/server/src/services/coursesService.ts
+++ b/apps/server/src/services/coursesService.ts
@@ -2,6 +2,7 @@ import Course from '../models/Course';
 import { Deck } from '../models/Deck';
 import { UserDeckStats } from '../models/UserDeckStats';
 import { User } from 'MemoryFlashCore/src/types/User';
+import { deleteDeckById } from './deckService';
 
 export async function createCourse(name: string, userId?: string) {
 	const course = new Course({ name, decks: [], userId });
@@ -28,4 +29,16 @@ export async function getDecksForCourse(courseId: string, user: User) {
 		userDeckStats,
 		course,
 	};
+}
+
+export async function renameCourse(courseId: string, name: string, userId: string) {
+	return Course.findOneAndUpdate({ _id: courseId, userId }, { name }, { new: true });
+}
+
+export async function deleteCourse(courseId: string, userId: string) {
+	const course = await Course.findOneAndDelete({ _id: courseId, userId });
+	if (!course) return;
+	for (const deckId of course.decks) {
+		await deleteDeckById(deckId.toString(), userId);
+	}
 }

--- a/apps/server/src/services/deckPermissions.test.ts
+++ b/apps/server/src/services/deckPermissions.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { setupDBConnectionForTesting } from '../config/test-setup';
+import { createCourse } from './coursesService';
+import { createDeck, renameDeck } from './deckService';
+import { User } from '../models';
+import { Deck } from '../models/Deck';
+
+describe('deck permissions', () => {
+	setupDBConnectionForTesting();
+
+	it("can't rename a deck you don't own", async () => {
+		const user1 = await new User({
+			firstName: 'A',
+			lastName: 'User',
+			email: 'a@test.com',
+			passwordHash: 'hash',
+		}).save();
+		const user2 = await new User({
+			firstName: 'B',
+			lastName: 'User',
+			email: 'b@test.com',
+			passwordHash: 'hash',
+		}).save();
+
+		const course = await createCourse('Test', user1._id.toString());
+		const deck = await createDeck(course._id.toString(), 'Original');
+
+		const updated = await renameDeck(deck._id.toString(), 'NewName', user2._id.toString());
+		expect(updated).to.be.null;
+		const persisted = await Deck.findById(deck._id);
+		expect(persisted?.name).to.equal('Original');
+	});
+});

--- a/packages/MemoryFlashCore/src/redux/actions/delete-course-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/delete-course-action.ts
@@ -1,0 +1,12 @@
+import { coursesActions } from '../slices/coursesSlice';
+import { AppThunk } from '../store';
+import { networkCallWithReduxState } from '../util/networkStateHelper';
+
+export const deleteCourse =
+	(courseId: string): AppThunk =>
+	async (dispatch, _, { api }) => {
+		await networkCallWithReduxState(dispatch, 'deleteCourse', async () => {
+			await api.delete('/courses/' + courseId);
+			dispatch(coursesActions.remove(courseId));
+		});
+	};

--- a/packages/MemoryFlashCore/src/redux/actions/delete-deck-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/delete-deck-action.ts
@@ -1,0 +1,12 @@
+import { decksActions } from '../slices/decksSlice';
+import { AppThunk } from '../store';
+import { networkCallWithReduxState } from '../util/networkStateHelper';
+
+export const deleteDeck =
+	(deckId: string): AppThunk =>
+	async (dispatch, _, { api }) => {
+		await networkCallWithReduxState(dispatch, 'deleteDeck', async () => {
+			await api.delete('/decks/' + deckId);
+			dispatch(decksActions.remove(deckId));
+		});
+	};

--- a/packages/MemoryFlashCore/src/redux/actions/rename-course-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/rename-course-action.ts
@@ -1,0 +1,12 @@
+import { coursesActions } from '../slices/coursesSlice';
+import { AppThunk } from '../store';
+import { networkCallWithReduxState } from '../util/networkStateHelper';
+
+export const renameCourse =
+	(courseId: string, name: string): AppThunk =>
+	async (dispatch, _, { api }) => {
+		await networkCallWithReduxState(dispatch, 'renameCourse', async () => {
+			const res = await api.patch('/courses/' + courseId, { name });
+			dispatch(coursesActions.upsert([res.data.course]));
+		});
+	};

--- a/packages/MemoryFlashCore/src/redux/actions/rename-deck-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/rename-deck-action.ts
@@ -1,0 +1,12 @@
+import { decksActions } from '../slices/decksSlice';
+import { AppThunk } from '../store';
+import { networkCallWithReduxState } from '../util/networkStateHelper';
+
+export const renameDeck =
+	(deckId: string, name: string): AppThunk =>
+	async (dispatch, _, { api }) => {
+		await networkCallWithReduxState(dispatch, 'renameDeck', async () => {
+			const res = await api.patch('/decks/' + deckId, { name });
+			dispatch(decksActions.upsert([res.data.deck]));
+		});
+	};

--- a/packages/MemoryFlashCore/src/redux/slices/coursesSlice.ts
+++ b/packages/MemoryFlashCore/src/redux/slices/coursesSlice.ts
@@ -18,6 +18,7 @@ const coursesSlice = createSlice({
 	initialState,
 	reducers: {
 		upsert: coursesAdapter.upsertMany,
+		remove: coursesAdapter.removeOne,
 		setParsingCourse(state, action: PayloadAction<string>) {
 			state.parsingCourse = action.payload;
 		},

--- a/packages/MemoryFlashCore/src/redux/slices/decksSlice.ts
+++ b/packages/MemoryFlashCore/src/redux/slices/decksSlice.ts
@@ -16,6 +16,7 @@ const decksSlice = createSlice({
 	initialState,
 	reducers: {
 		upsert: deckAdapter.upsertMany,
+		remove: deckAdapter.removeOne,
 	},
 });
 


### PR DESCRIPTION
## Summary
- inline course rename modal
- enforce ownership checks for renaming and deleting courses/decks
- pass user ID in course and deck routes
- test that users cannot rename another user's deck

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test` *(fails: MusicRecorder ignores notes beyond one measure)*

------
https://chatgpt.com/codex/tasks/task_e_685106c6913c8328a43449e13d1e2e85