### PR TITLE
Fix screenshot diff comment upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Unit Tests
 
 on: [pull_request]
 
+permissions:
+    contents: read
+    pull-requests: write
+
 jobs:
     test:
         runs-on: ubuntu-latest
@@ -43,3 +47,9 @@ jobs:
               run: yarn test
               env:
                   APP_URL: http://0.0.0.0:8008
+
+            - name: Comment screenshot diffs
+              if: failure() && github.event.pull_request
+              run: bash scripts/comment-screenshot-diffs.sh
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -104,6 +104,9 @@ export const NotationInputScreen = () => {
 
 	return (
 		<Layout subtitle="Notation Input" back="/">
+			<div id="test-fail" className="text-red-500 text-6xl mt-10">
+				Failing change
+			</div>
 			<NoteSettings keySig={keySig} setKeySig={setKeySig} dur={dur} setDur={setDur} />
 			<RangeSettings
 				lowest={lowest}

--- a/apps/react/tests/helpers.ts
+++ b/apps/react/tests/helpers.ts
@@ -1,1 +1,1 @@
-export const screenshotOpts = { maxDiffPixels: 10 };
+export const screenshotOpts = { maxDiffPixels: 1 };

--- a/scripts/comment-screenshot-diffs.sh
+++ b/scripts/comment-screenshot-diffs.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+DIR="apps/react/test-results"
+
+if [ ! -d "$DIR" ]; then
+  echo "No screenshot results directory: $DIR"
+  exit 0
+fi
+
+mapfile -t IMAGES < <(find "$DIR" -name '*-diff.png')
+echo "Found diff images: ${IMAGES[*]}"
+
+if [ ${#IMAGES[@]} -eq 0 ]; then
+  echo "No screenshot diffs found"
+  exit 0
+fi
+
+PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+  echo "Creating comment on PR #$PR_NUMBER"
+  COMMENT_JSON=$(gh api -X POST repos/"$GITHUB_REPOSITORY"/issues/"$PR_NUMBER"/comments -f body="Screenshot differences detected:") || {
+    echo "Failed to post comment. Possibly due to permissions."
+    exit 0
+  }
+  COMMENT_ID=$(echo "$COMMENT_JSON" | jq -r '.id')
+  echo "Comment ID: $COMMENT_ID"
+
+  BODY="Screenshot differences detected:\n"
+  COUNT=0
+  for IMG in "${IMAGES[@]}"; do
+    if [ $COUNT -ge 3 ]; then
+      break
+    fi
+    NAME=$(basename "$IMG")
+    SIZE=$(stat -c%s "$IMG")
+    echo "Uploading $NAME ($SIZE bytes)"
+    ATTACH=$(gh api -H "Accept: application/vnd.github+json" -X POST repos/"$GITHUB_REPOSITORY"/issues/"$PR_NUMBER"/comments/"$COMMENT_ID"/attachments -f name="$NAME" -F size="$SIZE") || {
+      echo "Failed to create attachment for $NAME"
+      continue
+    }
+    UPLOAD_URL=$(echo "$ATTACH" | jq -r '.upload_url')
+    URL=$(echo "$ATTACH" | jq -r '.url')
+    echo "Upload URL: $UPLOAD_URL"
+    curl -v -X PUT -H "Content-Type: image/png" --data-binary @"$IMG" "$UPLOAD_URL" || {
+      echo "Failed to upload image data for $NAME"
+      continue
+    }
+    BODY+="\n**$NAME**\n![$NAME]($URL)\n"
+    COUNT=$((COUNT + 1))
+  done
+
+  if [ ${#IMAGES[@]} -gt 3 ]; then
+    BODY+="\n...and $((${#IMAGES[@]} - 3)) more."
+  fi
+
+  gh api -X PATCH repos/"$GITHUB_REPOSITORY"/issues/comments/"$COMMENT_ID" -f body="$BODY" || echo "Failed to update comment"
+else
+  echo "No pull request context; skipping comment"
+fi
+


### PR DESCRIPTION
## Summary
- add debug output to screenshot diff comment script
- fix GitHub attachment path and log info when uploading images
- enlarge the intentional "Failing change" text
- lower maxDiffPixels to make screenshot diffs fail reliably

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test` *(fails: screenshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_685065c758a48328afe632091b94182d