### PR TITLE
Ensure recorder groups notes until released

### DIFF
--- a/apps/react/tests/music-recorder-chord-test.html
+++ b/apps/react/tests/music-recorder-chord-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicRecorder Chord Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/music-recorder-chord-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/music-recorder-chord-test.tsx
+++ b/apps/react/tests/music-recorder-chord-test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { createStore } from 'MemoryFlashCore/src/redux/store';
+import { MusicRecorder } from 'MemoryFlashCore/src/lib/MusicRecorder';
+
+const store = createStore({ scheduler: { multiPartCardIndex: 0 } } as any, () => {});
+(window as any).store = store;
+
+const recorder = new MusicRecorder('q');
+(window as any).recorder = recorder;
+
+const App: React.FC = () => {
+	const [data, setData] = React.useState(recorder.buildQuestion('C'));
+
+	React.useEffect(() => {
+		(window as any).update = () => setData(recorder.buildQuestion('C'));
+	}, []);
+
+	return <MusicNotation data={data} />;
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+	<React.StrictMode>
+		<Provider store={store}>
+			<App />
+		</Provider>
+	</React.StrictMode>,
+);

--- a/apps/react/tests/music-recorder-chord.spec.ts
+++ b/apps/react/tests/music-recorder-chord.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import { screenshotOpts } from './helpers';
+
+test('MusicRecorder chord screenshot', async ({ page }) => {
+	await page.goto('/tests/music-recorder-chord-test.html');
+	const output = page.locator('#output');
+	const events = [[60], [60, 64], [60, 64, 67], [], [65]];
+
+	for (let i = 0; i < events.length; i++) {
+		await page.evaluate((notes) => {
+			(window as any).recorder.addMidiNotes(notes);
+			(window as any).update();
+		}, events[i]);
+		await output.waitFor();
+		await expect(output).toHaveScreenshot(`music-recorder-chord-${i + 1}.png`, screenshotOpts);
+	}
+});

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
@@ -32,7 +32,48 @@ describe('MusicRecorder', () => {
 		const r = new MusicRecorder('q');
 		for (const n of [60, 62, 64, 65, 67]) {
 			r.addMidiNotes([n]);
+			r.addMidiNotes([]); // release
 		}
 		expect(r.notes.length).to.equal(4);
+	});
+
+	it('records new stack only after notes released', () => {
+		const r = new MusicRecorder('q');
+		r.addMidiNotes([60]);
+		r.addMidiNotes([60, 64]);
+		r.addMidiNotes([64]);
+		r.addMidiNotes([]);
+		r.addMidiNotes([65]);
+		expect(r.notes).to.deep.equal([
+			{
+				notes: [
+					{ name: 'C', octave: 4 },
+					{ name: 'E', octave: 4 },
+				],
+				duration: 'q',
+			},
+			{
+				notes: [{ name: 'F', octave: 4 }],
+				duration: 'q',
+			},
+		]);
+	});
+
+	it('stacks additional notes until released', () => {
+		const r = new MusicRecorder('q');
+		r.addMidiNotes([60]);
+		r.addMidiNotes([60, 64]);
+		r.addMidiNotes([60, 64, 67]);
+		r.addMidiNotes([]);
+		expect(r.notes).to.deep.equal([
+			{
+				notes: [
+					{ name: 'C', octave: 4 },
+					{ name: 'E', octave: 4 },
+					{ name: 'G', octave: 4 },
+				],
+				duration: 'q',
+			},
+		]);
 	});
 });

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -20,18 +20,32 @@ export class MusicRecorder {
 		const beatsSoFar = this.notes.reduce((sum, n) => sum + durationBeats[n.duration], 0);
 		const beats = durationBeats[this.duration];
 		if (beatsSoFar + beats > this._maxBeats) {
+			this.prevMidiNotes = midiNotes;
 			return;
 		}
 
+		const wasHolding = this.prevMidiNotes.length > 0;
+		const isHolding = midiNotes.length > 0;
 		const added = midiNotes.filter((m) => !this.prevMidiNotes.includes(m));
-		if (added.length) {
-			const sheetNotes = added.map((m) => {
+
+		const toSheet = (nums: number[]) =>
+			nums.map((m) => {
 				const name = Midi.midiToNoteName(m);
 				const match = name.match(/([A-G][#b]?)(\d+)/)!;
 				return { name: match[1], octave: parseInt(match[2]) };
 			});
-			this.notes.push({ notes: sheetNotes, duration: this.duration });
+
+		if (!wasHolding && isHolding) {
+			this.notes.push({ notes: toSheet(midiNotes), duration: this.duration });
+		} else if (wasHolding && isHolding && added.length && this.notes.length) {
+			const current = this.notes[this.notes.length - 1];
+			const existing = new Set(current.notes.map((n) => `${n.name}${n.octave}`));
+			for (const n of toSheet(added)) {
+				if (!existing.has(`${n.name}${n.octave}`)) current.notes.push(n);
+			}
 		}
+
+		this.prevMidiNotes = midiNotes;
 	}
 
 	removeLast(): void {


### PR DESCRIPTION
## Summary
- simplify MusicRecorder's stacking logic
- extend unit tests with additional chord stacking case
- update Playwright test to capture screenshots after each note event
- make harness page expose update hook for screenshots

## Testing
- `yarn workspace MemoryFlashReact test:screenshots:update`
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_6851194ca1f083289023370fdafbe6b8