### PR TITLE
Add screenshot uploader on test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ jobs:
     test:
         name: Test
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
 
         strategy:
             matrix:
@@ -41,6 +44,25 @@ jobs:
               run: npx playwright install --with-deps
 
             - name: Run unit tests
+              id: tests
               run: yarn test
+              continue-on-error: true
               env:
                   APP_URL: http://0.0.0.0:8008
+
+            - name: Authenticate on GCS
+              if: steps.tests.outcome == 'failure'
+              uses: google-github-actions/auth@v2
+              with:
+                  credentials_json: ${{ secrets.GCP_MFLASH_PROD_JSON_KEY }}
+
+            - name: Upload screenshots and comment
+              if: steps.tests.outcome == 'failure'
+              run: ./scripts/report-test-failure.sh
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  GITHUB_TOKEN: ${{ github.token }}
+
+            - name: Fail workflow if tests failed
+              if: steps.tests.outcome == 'failure'
+              run: exit 1

--- a/scripts/report-test-failure.sh
+++ b/scripts/report-test-failure.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUCKET="mflash-github-test-reports"
+RESULTS_DIR="apps/react/test-results"
+
+if [ ! -d "$RESULTS_DIR" ]; then
+echo "No test-results directory"
+exit 0
+fi
+
+shopt -s globstar nullglob
+files=("$RESULTS_DIR"/**/*.png)
+if [ ${#files[@]} -eq 0 ]; then
+echo "No screenshots to upload"
+exit 0
+fi
+
+COMMIT_SHA="${COMMIT_SHA:-${GITHUB_SHA:-$(git rev-parse HEAD)}}"
+TIMESTAMP=$(date +%s)
+DEST="gs://$BUCKET/${COMMIT_SHA}-${TIMESTAMP}/"
+
+# Upload screenshots
+printf 'Uploading screenshots to %s\n' "$DEST"
+# gsutil prints progress to stderr so we hide it
+if ! gsutil -m cp "${files[@]}" "$DEST" >/dev/null; then
+echo "gsutil upload failed"
+exit 1
+fi
+
+URL_PREFIX="https://storage.googleapis.com/$BUCKET/${COMMIT_SHA}-${TIMESTAMP}/"
+
+body="Test failures detected. Screenshots uploaded:\n"
+for f in "${files[@]}"; do
+base=$(basename "$f")
+body+="${URL_PREFIX}${base}\n"
+done
+
+if [ -n "${PR_NUMBER:-}" ]; then
+gh pr comment "$PR_NUMBER" --body "$body"
+fi


### PR DESCRIPTION
## Summary
- comment failing test screenshots on PRs
- authenticate to upload screenshots to Cloud Storage

## Testing
- `npx prettier --write .`
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_68522942203c8328b897ca4a98aa7ae8