### PR TITLE
Update MusicRecorder with new note detection

### DIFF
--- a/apps/react/tests/notation-input-step.spec.ts
+++ b/apps/react/tests/notation-input-step.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { screenshotOpts } from './helpers';
+
+const press = async (page: any, midi: number) => {
+	await page.evaluate((n) => {
+		(window as any).store.dispatch({ type: 'midi/addNote', payload: n });
+	}, midi);
+	await page.evaluate((n) => {
+		(window as any).store.dispatch({ type: 'midi/removeNote', payload: n });
+	}, midi);
+};
+
+test('screenshot after each note on', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(msg.text());
+	});
+
+	await page.goto('/tests/notation-input-screen-test.html');
+	const output = page.locator('#root');
+	await output.waitFor();
+
+	await page.waitForTimeout(200);
+	await expect(output).toHaveScreenshot('notation-step-0.png', screenshotOpts);
+
+	let idx = 1;
+	for (const m of [60, 62, 64]) {
+		await press(page, m);
+		await page.waitForTimeout(200);
+		await expect(output).toHaveScreenshot(`notation-step-${idx}.png`, screenshotOpts);
+		idx++;
+	}
+
+	expect(errors).toEqual([]);
+});

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
@@ -28,6 +28,16 @@ describe('MusicRecorder', () => {
 		expect(r.filledNotes).to.deep.equal([{ notes: [], duration: 'w', rest: true }]);
 	});
 
+	it('only records newly pressed notes', () => {
+		const r = new MusicRecorder('q');
+		r.addMidiNotes([60]);
+		r.addMidiNotes([60, 64]);
+		expect(r.notes).to.deep.equal([
+			{ notes: [{ name: 'C', octave: 4 }], duration: 'q' },
+			{ notes: [{ name: 'E', octave: 4 }], duration: 'q' },
+		]);
+	});
+
 	it('ignores notes beyond one measure', () => {
 		const r = new MusicRecorder('q');
 		for (const n of [60, 62, 64, 65, 67]) {

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -16,22 +16,21 @@ export class MusicRecorder {
 	}
 
 	addMidiNotes(midiNotes: number[]): void {
-		// Do we have max beats?
+		const added = midiNotes.filter((m) => !this.prevMidiNotes.includes(m));
+		this.prevMidiNotes = [...midiNotes];
+
+		if (!added.length) return;
+
 		const beatsSoFar = this.notes.reduce((sum, n) => sum + durationBeats[n.duration], 0);
 		const beats = durationBeats[this.duration];
-		if (beatsSoFar + beats > this._maxBeats) {
-			return;
-		}
+		if (beatsSoFar + beats > this._maxBeats) return;
 
-		const added = midiNotes.filter((m) => !this.prevMidiNotes.includes(m));
-		if (added.length) {
-			const sheetNotes = added.map((m) => {
-				const name = Midi.midiToNoteName(m);
-				const match = name.match(/([A-G][#b]?)(\d+)/)!;
-				return { name: match[1], octave: parseInt(match[2]) };
-			});
-			this.notes.push({ notes: sheetNotes, duration: this.duration });
-		}
+		const sheetNotes = added.map((m) => {
+			const name = Midi.midiToNoteName(m);
+			const match = name.match(/([A-G][#b]?)(\d+)/)!;
+			return { name: match[1], octave: parseInt(match[2]) };
+		});
+		this.notes.push({ notes: sheetNotes, duration: this.duration });
 	}
 
 	removeLast(): void {


### PR DESCRIPTION
## Summary
- update `MusicRecorder.addMidiNotes` to track previously pressed notes
- cover new behaviour in unit tests
- screenshot test to verify screen updates after each note

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_6852289e40f0832891d6645b21394bd0