### PR TITLE
Add iOS debug settings access on auth pages

### DIFF
--- a/apps/react/src/components/AuthForm.tsx
+++ b/apps/react/src/components/AuthForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { OpenSettingsButton } from './OpenSettingsButton';
 
 interface AuthFormProps {
 	title: string;
@@ -8,7 +9,10 @@ interface AuthFormProps {
 
 export const AuthForm: React.FC<AuthFormProps> = ({ title, onSubmit, children }) => {
 	return (
-		<div className="flex min-h-full flex-1 flex-col justify-center py-12 sm:px-6 lg:px-8">
+		<div className="relative flex min-h-full flex-1 flex-col justify-center py-12 sm:px-6 lg:px-8">
+			<div className="absolute right-6 top-6">
+				<OpenSettingsButton />
+			</div>
 			<div className="sm:mx-auto sm:w-full sm:max-w-md">
 				<h2 className="mt-6 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
 					{title}

--- a/apps/react/src/components/OpenSettingsButton.tsx
+++ b/apps/react/src/components/OpenSettingsButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Cog6ToothIcon } from '@heroicons/react/24/outline';
+import { CircleHover } from './CircleHover';
+import { isIOSDebug } from '../utils/isIOSDebug';
+
+export const OpenSettingsButton: React.FC = () => {
+	if (!isIOSDebug()) return null;
+	return (
+		<CircleHover
+			onClick={() => (window as any).webkit?.messageHandlers?.openSettings?.postMessage('')}
+		>
+			<Cog6ToothIcon className="w-6 h-6 stroke-2" />
+		</CircleHover>
+	);
+};


### PR DESCRIPTION
## Summary
- show a gear icon for iOS debug users
- render it in `AuthForm` so Login and Sign Up can open native settings

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_685253e204588328a4a7de78efe697be