### PR TITLE
Fix CORS origin in server

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -6,7 +6,7 @@ import cors from 'cors';
 import express, { Express } from 'express';
 import session from 'express-session';
 import type { MongoClient } from 'mongodb';
-import { APP_DOMAIN, IS_PROD, SESSION_OPTS, APP_URL, passport } from './config';
+import { APP_DOMAIN, IS_PROD, SESSION_OPTS, APP_URL, FRONT_END_URL, passport } from './config';
 import { customErrorHandler } from './middleware';
 import { devSleep } from './middleware/devSleep';
 import { api } from './routes';
@@ -34,6 +34,7 @@ const setupMiddlewaresAndRoutes = (server: Express, dbClient: MongoClient) => {
 		corsOrigins.push(/.*/);
 	}
 	corsOrigins.push(APP_URL);
+	corsOrigins.push(FRONT_END_URL);
 	server.use(
 		cors({
 			origin: corsOrigins,

--- a/apps/server/src/config/constants.ts
+++ b/apps/server/src/config/constants.ts
@@ -2,6 +2,7 @@ import { SessionOptions } from 'express-session';
 import { oneDayInMillis, oneMinInMillis } from '../utils/dates';
 
 export const APP_URL = process.env.APP_URL || 'http://localhost:3000';
+export const FRONT_END_URL = process.env.FRONT_END_URL || APP_URL;
 export const APP_DOMAIN = new URL(APP_URL).hostname;
 export const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- allow the server to read `FRONT_END_URL`
- configure CORS to include this origin unconditionally

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_6852586a03488328babab84e2e324acd