### PR TITLE
Add console error viewer for iOS debug

### DIFF
--- a/apps/react/src/components/ConsoleErrorsButton.tsx
+++ b/apps/react/src/components/ConsoleErrorsButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { CircleHover } from './CircleHover';
+import { Modal } from './modals/Modal';
+import { useConsoleErrors } from '../utils/useConsoleErrors';
+import { isIOSDebug } from '../utils/isIOSDebug';
+
+export const ConsoleErrorsButton: React.FC = () => {
+	const errors = useConsoleErrors();
+	const [open, setOpen] = React.useState(false);
+
+	if (!isIOSDebug() || errors.length === 0) return null;
+
+	return (
+		<>
+			<CircleHover onClick={() => setOpen(true)}>
+				<ExclamationTriangleIcon className="w-6 h-6 stroke-2 text-red-600" />
+			</CircleHover>
+			<Modal isOpen={open} onClose={() => setOpen(false)} title="Console Errors">
+				<div className="px-6 pb-6 space-y-2 max-h-80 overflow-y-auto">
+					{errors.map((e, i) => (
+						<p key={i} className="text-sm text-red-600 break-words">
+							{e}
+						</p>
+					))}
+				</div>
+			</Modal>
+		</>
+	);
+};

--- a/apps/react/src/components/Layout.tsx
+++ b/apps/react/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { CircleHover } from './CircleHover';
 import { MidiInputsDropdown } from './MidiInputsDropdown';
 import { AccountNavButton } from './navigation/AccountNavButton';
 import { isIOSDebug } from '../utils/isIOSDebug';
+import { ConsoleErrorsButton } from './ConsoleErrorsButton';
 
 interface LayoutProps {
 	children: React.ReactNode;
@@ -58,9 +59,12 @@ export const Layout: React.FC<LayoutProps> = ({
 				<div className="flex flex-row-reverse items-center gap-3">
 					{rightContent}
 					{iosDebug && (
-						<CircleHover onClick={() => window.location.reload()}>
-							<ArrowPathIcon className="w-6 h-6 stroke-2" />
-						</CircleHover>
+						<>
+							<ConsoleErrorsButton />
+							<CircleHover onClick={() => window.location.reload()}>
+								<ArrowPathIcon className="w-6 h-6 stroke-2" />
+							</CircleHover>
+						</>
 					)}
 				</div>
 			</div>

--- a/apps/react/src/components/index.ts
+++ b/apps/react/src/components/index.ts
@@ -13,3 +13,4 @@ export * from './modals/Modal';
 export * from './modals/InputModal';
 export * from './modals/ConfirmModal';
 export * from './CardOptionsMenu';
+export * from './ConsoleErrorsButton';

--- a/apps/react/src/utils/consoleErrors.ts
+++ b/apps/react/src/utils/consoleErrors.ts
@@ -1,0 +1,33 @@
+import { isIOSDebug } from './isIOSDebug';
+
+let initialized = false;
+const errors: string[] = [];
+type Subscriber = (errs: string[]) => void;
+const subs: Subscriber[] = [];
+
+const notify = () => {
+	subs.forEach((fn) => fn([...errors]));
+};
+
+export const initConsoleErrorCapture = () => {
+	if (initialized || !isIOSDebug()) return;
+	initialized = true;
+	const orig = console.error;
+	console.error = (...args: any[]) => {
+		const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+		errors.push(msg);
+		notify();
+		orig(...args);
+	};
+};
+
+export const subscribeConsoleErrors = (fn: Subscriber) => {
+	subs.push(fn);
+	fn([...errors]);
+	return () => {
+		const idx = subs.indexOf(fn);
+		if (idx >= 0) subs.splice(idx, 1);
+	};
+};
+
+export const getConsoleErrors = () => [...errors];

--- a/apps/react/src/utils/useConsoleErrors.ts
+++ b/apps/react/src/utils/useConsoleErrors.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+import { getConsoleErrors, initConsoleErrorCapture, subscribeConsoleErrors } from './consoleErrors';
+
+export const useConsoleErrors = (): string[] => {
+	const [errs, setErrs] = React.useState<string[]>(getConsoleErrors());
+	React.useEffect(() => {
+		initConsoleErrorCapture();
+		return subscribeConsoleErrors(setErrs);
+	}, []);
+	return errs;
+};


### PR DESCRIPTION
## Summary
- capture console errors in iOS debug mode
- provide hook for subscribing to console errors
- add button to show errors in a modal
- expose new component and integrate it into the layout

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_68525a5bbad88328a73dac989a0ef658