### PR TITLE
Update mongoose to latest

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,7 +23,7 @@
 		"express": "^4.19.2",
 		"express-session": "^1.18.0",
 		"express-winston": "^4.2.0",
-		"mongoose": "^8.6.0",
+		"mongoose": "^8.16.0",
 		"passport": "^0.7.0",
 		"passport-local": "^1.0.0",
 		"tonal": "^6.2.0",

--- a/apps/server/src/models/Card.ts
+++ b/apps/server/src/models/Card.ts
@@ -30,7 +30,6 @@ const CardSchema = new Schema<CardDoc>(
 	{
 		toJSON: {
 			transform: (_, ret: Partial<CardDoc>) => {
-				delete ret.__v;
 				delete ret.updatedAt;
 			},
 		},

--- a/apps/server/src/models/Deck.ts
+++ b/apps/server/src/models/Deck.ts
@@ -28,7 +28,6 @@ const DeckSchema = new Schema<DeckDoc>(
 	{
 		toJSON: {
 			transform: (_, ret: Partial<DeckDoc>) => {
-				delete ret.__v;
 				delete ret.updatedAt;
 			},
 		},

--- a/apps/server/src/models/ForgotPassword.ts
+++ b/apps/server/src/models/ForgotPassword.ts
@@ -23,7 +23,6 @@ const ForgotPasswordSchema = new Schema<ForgotPasswordDoc>(
 	{
 		toJSON: {
 			transform: (_, ret: Partial<ForgotPasswordDoc>) => {
-				delete ret.__v;
 				delete ret.updatedAt;
 			},
 		},

--- a/apps/server/src/models/User.ts
+++ b/apps/server/src/models/User.ts
@@ -49,7 +49,6 @@ const UserSchema = new Schema<UserDoc>(
 	{
 		toJSON: {
 			transform: (_, ret: Partial<UserDoc>) => {
-				delete ret.__v;
 				delete ret.createdAt;
 				delete ret.updatedAt;
 				delete ret.passwordHash;

--- a/apps/server/src/models/UserDeckStats.ts
+++ b/apps/server/src/models/UserDeckStats.ts
@@ -30,7 +30,6 @@ const UserDeckStatsSchema = new Schema<UserDeckStatsDoc>(
 	{
 		toJSON: {
 			transform: (_, ret: Partial<UserDeckStatsDoc>) => {
-				delete ret.__v;
 				delete ret.updatedAt;
 			},
 		},

--- a/packages/MemoryFlashCore/package.json
+++ b/packages/MemoryFlashCore/package.json
@@ -21,7 +21,7 @@
 		"@types/react-redux": "^7.1.33",
 		"axios": "^1.8.2",
 		"bson-objectid": "^2.0.4",
-		"mongoose": "^8.6.0",
+		"mongoose": "^8.16.0",
 		"tonal": "^6.2.0",
 		"zod": "^3.22.4"
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,6 +710,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mongodb-js/saslprep@npm:^1.1.9":
+  version: 1.3.0
+  resolution: "@mongodb-js/saslprep@npm:1.3.0"
+  dependencies:
+    sparse-bitfield: "npm:^3.0.3"
+  checksum: 10c0/d51bbeaf04bbd9c019bbd9178c035ae3e3f0d64f6cfc85bc5e745aefdcedc0b4fa1b8dc139a7fe07804943bd36043bfc5a6f1a72c5e547a689078af1f7d0f168
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -1987,7 +1996,7 @@ __metadata:
     chai: "npm:^4.3.10"
     concurrently: "npm:^9.0.1"
     mocha: "npm:^10.2.0"
-    mongoose: "npm:^8.6.0"
+    mongoose: "npm:^8.16.0"
     tonal: "npm:^6.2.0"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.5.4"
@@ -2065,7 +2074,7 @@ __metadata:
     husky: "npm:^8.0.3"
     mocha: "npm:^10.2.0"
     mongodb-memory-server: "npm:^10.0.0"
-    mongoose: "npm:^8.6.0"
+    mongoose: "npm:^8.16.0"
     nodemon: "npm:^3.0.1"
     passport: "npm:^0.7.0"
     passport-local: "npm:^1.0.0"
@@ -2490,6 +2499,13 @@ __metadata:
   version: 2.0.4
   resolution: "bson-objectid@npm:2.0.4"
   checksum: 10c0/9dbe55a8cd5ed5ddae0c971429a34caadcf38bc5b98070302e740be2e3c04ab2280925c8f4cba28c88e13f51018dff7d674c610370847286e27e6d76c8990a3f
+  languageName: node
+  linkType: hard
+
+"bson@npm:^6.10.4":
+  version: 6.10.4
+  resolution: "bson@npm:6.10.4"
+  checksum: 10c0/6c6819ce642516901349f42c5d9d131d5a4e84352a3859c814d4abf6b2b9249e3685b57fc4cf7b5737fb5c71252f65900a41826c1429815a93e43f0f5bb3c173
   languageName: node
   linkType: hard
 
@@ -5086,7 +5102,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongoose@npm:*, mongoose@npm:^8.6.0":
+"mongodb@npm:~6.17.0":
+  version: 6.17.0
+  resolution: "mongodb@npm:6.17.0"
+  dependencies:
+    "@mongodb-js/saslprep": "npm:^1.1.9"
+    bson: "npm:^6.10.4"
+    mongodb-connection-string-url: "npm:^3.0.0"
+  peerDependencies:
+    "@aws-sdk/credential-providers": ^3.188.0
+    "@mongodb-js/zstd": ^1.1.0 || ^2.0.0
+    gcp-metadata: ^5.2.0
+    kerberos: ^2.0.1
+    mongodb-client-encryption: ">=6.0.0 <7"
+    snappy: ^7.2.2
+    socks: ^2.7.1
+  peerDependenciesMeta:
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@mongodb-js/zstd":
+      optional: true
+    gcp-metadata:
+      optional: true
+    kerberos:
+      optional: true
+    mongodb-client-encryption:
+      optional: true
+    snappy:
+      optional: true
+    socks:
+      optional: true
+  checksum: 10c0/97630cbb12a7615230f4846220acd68b82d8ae5e12eb83beb239a48c88604766a7cf2b114a20e774ada7be35175c02e23d66b05f3d180c667620a1ba8b1a52b5
+  languageName: node
+  linkType: hard
+
+"mongoose@npm:*":
   version: 8.6.3
   resolution: "mongoose@npm:8.6.3"
   dependencies:
@@ -5098,6 +5148,21 @@ __metadata:
     ms: "npm:2.1.3"
     sift: "npm:17.1.3"
   checksum: 10c0/60d4333077ed0248916e546efc7f4c8d08d0ad4f69f7aea625c009afeb38089b0d260561ae5bbeaef33f2cff8ce009c0a8774fda3b00be2453bd97083b61e9a7
+  languageName: node
+  linkType: hard
+
+"mongoose@npm:^8.16.0":
+  version: 8.16.0
+  resolution: "mongoose@npm:8.16.0"
+  dependencies:
+    bson: "npm:^6.10.4"
+    kareem: "npm:2.6.3"
+    mongodb: "npm:~6.17.0"
+    mpath: "npm:0.9.0"
+    mquery: "npm:5.0.0"
+    ms: "npm:2.1.3"
+    sift: "npm:17.1.3"
+  checksum: 10c0/99064a98e9397501c5eb20d41d837486d45b8554b2a28fb8cc51adf29261d5d066da0628e5fdeeed9a4d1a1c24e49c248823d55cfa76574ef21865c381046e63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- bump mongoose to v8.16.0
- drop the extra `__v` deletion logic from model transforms
- revert user deck stats adapter and helper types

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68512052f3c0832894c36c1056cf318a