### PR TITLE
Increase Playwright screenshot pixel ratio

### DIFF
--- a/apps/react/playwright.config.ts
+++ b/apps/react/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
+const deviceScaleFactor = ['linux', 'darwin'].includes(process.platform) ? 2 : 1;
+
 export default defineConfig({
 	testDir: './tests',
 	snapshotPathTemplate: '{testDir}/{testFilePath}-snapshots/{arg}{ext}',
@@ -11,6 +13,7 @@ export default defineConfig({
 	use: {
 		baseURL: 'http://localhost:4173',
 		screenshot: 'only-on-failure',
+		deviceScaleFactor,
 	},
 	reporter: [['html', { open: 'never' }]],
 });


### PR DESCRIPTION
## Summary
- tweak Playwright config to capture high-DPI screenshots on Linux/Darwin

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_68525ee05ec083288a8654442df67c62