### PR TITLE
Fix UserDeckStats types

### DIFF
--- a/apps/server/src/models/UserDeckStats.ts
+++ b/apps/server/src/models/UserDeckStats.ts
@@ -1,7 +1,7 @@
 import { Document, model, Schema } from 'mongoose';
-import { UserDeckStatsType } from 'MemoryFlashCore/src/types/UserDeckStats';
+import { UserDeckStatsMongo } from 'MemoryFlashCore/src/types/UserDeckStats';
 
-export type UserDeckStatsDoc = UserDeckStatsType & Document;
+export type UserDeckStatsDoc = UserDeckStatsMongo & Document;
 
 const UserDeckStatsSchema = new Schema<UserDeckStatsDoc>(
 	{

--- a/packages/MemoryFlashCore/src/types/UserDeckStats.ts
+++ b/packages/MemoryFlashCore/src/types/UserDeckStats.ts
@@ -3,9 +3,9 @@ import { MongoId } from './helper-types';
 export type MedianHistoryValue = { median: number; date: Date };
 export type MedianHistory = MedianHistoryValue[];
 export type UserDeckStatsType = {
-	_id: MongoId;
-	userId: MongoId;
-	deckId: MongoId;
+	_id: string;
+	userId: string;
+	deckId: string;
 	attempts: {
 		[key: string]: number; // time taken
 	};
@@ -13,4 +13,10 @@ export type UserDeckStatsType = {
 	medianHistory: MedianHistory;
 	createdAt: Date;
 	updatedAt: Date;
+};
+
+export type UserDeckStatsMongo = Omit<UserDeckStatsType, '_id' | 'userId' | 'deckId'> & {
+	_id: MongoId;
+	userId: MongoId;
+	deckId: MongoId;
 };


### PR DESCRIPTION
## Summary
- use string-based UserDeckStats entity inside MemoryFlashCore
- add Mongo-specific type and update server model to consume it

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_685264178c388328bcfd4eaed88e4a89