### PR TITLE
Fix module resolution for server

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
 		"dev": "nodemon src/app.ts",
 		"format": "prettier --write \"src/**/*.{ts,json}\"",
 		"lint": "eslint src/**/*.ts",
-		"start:prod": "node dist/app.js",
+		"start:prod": "NODE_PATH=../../packages node dist/app.js",
 		"test": "NODE_ENV=test mocha --timeout 10000 --require ts-node/register --require dotenv/config src/**/*.test.ts",
 		"test:watch": "nodemon --ext ts --exec 'yarn test'"
 	},


### PR DESCRIPTION
## Summary
- set `NODE_PATH` in server's production start script

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build` *(fails: Type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852646205f88328bb89b6e722493798