### PR TITLE
Fix server startup by loading TS modules

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
 		"dev": "nodemon src/app.ts",
 		"format": "prettier --write \"src/**/*.{ts,json}\"",
 		"lint": "eslint src/**/*.ts",
-		"start:prod": "node dist/app.js",
+		"start:prod": "node -r ts-node/register dist/app.js",
 		"test": "NODE_ENV=test mocha --timeout 10000 --require ts-node/register --require dotenv/config src/**/*.test.ts",
 		"test:watch": "nodemon --ext ts --exec 'yarn test'"
 	},

--- a/packages/MemoryFlashCore/tsconfig.json
+++ b/packages/MemoryFlashCore/tsconfig.json
@@ -9,7 +9,9 @@
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"module": "commonjs",
 		"moduleResolution": "node",
-		"noEmit": true,
+		"outDir": "dist",
+		"declaration": true,
+		"declarationDir": "dist",
 		"noUnusedLocals": false,
 		"noUnusedParameters": false,
 		"resolveJsonModule": true,
@@ -18,5 +20,6 @@
 		"target": "es5",
 		"composite": true
 	},
-	"include": ["src"]
+	"include": ["src"],
+	"exclude": ["src/redux/env.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {
-			"MemoryFlashCore/*": ["packages/MemoryFlashCore/src/*"]
+			"MemoryFlashCore/*": ["packages/MemoryFlashCore/dist/*"]
 		},
 		"moduleResolution": "node"
 	},


### PR DESCRIPTION
## Summary
- build MemoryFlashCore to allow JS output and exclude Redux env helper
- update root `tsconfig` paths to use built files
- run server in production with `ts-node/register` so TS modules resolve

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_68526b28d6e88328ae5b88d0d992f3fa