### PR TITLE
Block fonts during screenshot tests

### DIFF
--- a/apps/react/package.json
+++ b/apps/react/package.json
@@ -8,8 +8,8 @@
 		"build": "tsc && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview",
-		"test:screenshots": "BLOCK_FONTS=true playwright test",
-		"test:screenshots:update": "BLOCK_FONTS=true playwright test --update-snapshots",
+		"test:screenshots": "BLOCK_REMOTE_FONTS=true playwright test",
+		"test:screenshots:update": "BLOCK_REMOTE_FONTS=true playwright test --update-snapshots",
 		"postinstall": "./scripts/install-playwright.sh"
 	},
 	"dependencies": {

--- a/apps/react/package.json
+++ b/apps/react/package.json
@@ -8,8 +8,8 @@
 		"build": "tsc && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview",
-		"test:screenshots": "playwright test",
-		"test:screenshots:update": "playwright test --update-snapshots",
+		"test:screenshots": "BLOCK_FONTS=true playwright test",
+		"test:screenshots:update": "BLOCK_FONTS=true playwright test --update-snapshots",
 		"postinstall": "./scripts/install-playwright.sh"
 	},
 	"dependencies": {

--- a/apps/react/tests/helpers.ts
+++ b/apps/react/tests/helpers.ts
@@ -1,1 +1,17 @@
+import { test as base, expect, Page } from '@playwright/test';
+
 export const screenshotOpts = { maxDiffPixelRatio: 0.015 };
+
+const blockFonts = process.env.BLOCK_FONTS === 'true';
+
+export const test = base.extend<{ page: Page }>({
+	page: async ({ page }, use) => {
+		if (blockFonts) {
+			await page.route('https://fonts.googleapis.com/**', (route) => route.abort());
+			await page.route('https://fonts.gstatic.com/**', (route) => route.abort());
+		}
+		await use(page);
+	},
+});
+
+export { expect };

--- a/apps/react/tests/helpers.ts
+++ b/apps/react/tests/helpers.ts
@@ -2,7 +2,8 @@ import { test as base, expect, Page } from '@playwright/test';
 
 export const screenshotOpts = { maxDiffPixelRatio: 0.015 };
 
-const blockFonts = process.env.BLOCK_FONTS === 'true';
+// If the font does/doesn't load can cause small differences making tests more flaky
+const blockFonts = process.env.BLOCK_REMOTE_FONTS === 'true';
 
 export const test = base.extend<{ page: Page }>({
 	page: async ({ page }, use) => {

--- a/apps/react/tests/music-notation-eighth.spec.ts
+++ b/apps/react/tests/music-notation-eighth.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicNotation eighth notes screenshot', async ({ page }) => {
 	await page.goto('/tests/music-notation-eighth-test.html');

--- a/apps/react/tests/music-notation-half-quarter.spec.ts
+++ b/apps/react/tests/music-notation-half-quarter.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicNotation half and quarter notes screenshot', async ({ page }) => {
 	await page.goto('/tests/music-notation-half-quarter-test.html');

--- a/apps/react/tests/music-notation-highlight.spec.ts
+++ b/apps/react/tests/music-notation-highlight.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts } from './helpers';
 
 test.describe('highlight notes', () => {
 	for (const index of [1, 2, 3, 4]) {

--- a/apps/react/tests/music-notation-rest.spec.ts
+++ b/apps/react/tests/music-notation-rest.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicNotation rests screenshot', async ({ page }) => {
 	await page.goto('/tests/music-notation-rest-test.html');

--- a/apps/react/tests/music-notation.spec.ts
+++ b/apps/react/tests/music-notation.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicNotation component screenshot', async ({ page }) => {
 	await page.goto('/tests/music-notation-test.html');

--- a/apps/react/tests/music-recorder-chord.spec.ts
+++ b/apps/react/tests/music-recorder-chord.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicRecorder chord screenshot', async ({ page }) => {
 	await page.goto('/tests/music-recorder-chord-test.html');

--- a/apps/react/tests/notation-input-overflow.spec.ts
+++ b/apps/react/tests/notation-input-overflow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './helpers';
 
 test('NotationInputScreen handles overflow input', async ({ page }) => {
 	let errors: string[] = [];

--- a/apps/react/tests/notation-input-screen.spec.ts
+++ b/apps/react/tests/notation-input-screen.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test';
-import { screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts } from './helpers';
 import fs from 'fs';
 import path from 'path';
 


### PR DESCRIPTION
## Summary
- ensure Playwright aborts font requests only when `BLOCK_FONTS=true`
- combine helpers imports in specs

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_68527eab117c8328bfd987cc8a3c9939