### PR TITLE
Fix server imports by running with ts-node

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
 		"passport-local": "^1.0.0",
 		"tonal": "^6.2.0",
 		"ts-node": "^10.9.1",
+		"typescript": "^5.2.2",
 		"winston": "^3.11.0"
 	},
 	"devDependencies": {
@@ -51,8 +52,7 @@
 		"mocha": "^10.2.0",
 		"mongodb-memory-server": "^10.0.0",
 		"nodemon": "^3.0.1",
-		"prettier": "^3.0.3",
-		"typescript": "^5.2.2"
+		"prettier": "^3.0.3"
 	},
 	"husky": {
 		"hooks": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
 		"dev": "nodemon src/app.ts",
 		"format": "prettier --write \"src/**/*.{ts,json}\"",
 		"lint": "eslint src/**/*.ts",
-		"start:prod": "node dist/app.js",
+		"start:prod": "ts-node --transpile-only src/app.ts",
 		"test": "NODE_ENV=test mocha --timeout 10000 --require ts-node/register --require dotenv/config src/**/*.test.ts",
 		"test:watch": "nodemon --ext ts --exec 'yarn test'"
 	},

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,6 +27,7 @@
 		"passport": "^0.7.0",
 		"passport-local": "^1.0.0",
 		"tonal": "^6.2.0",
+		"ts-node": "^10.9.1",
 		"winston": "^3.11.0"
 	},
 	"devDependencies": {
@@ -51,7 +52,6 @@
 		"mongodb-memory-server": "^10.0.0",
 		"nodemon": "^3.0.1",
 		"prettier": "^3.0.3",
-		"ts-node": "^10.9.1",
 		"typescript": "^5.2.2"
 	},
 	"husky": {


### PR DESCRIPTION
## Summary
- revert MemoryFlashCore tsconfig to noEmit
- remove path mapping from the server tsconfig
- run the server in production with `ts-node`

## Testing
- `yarn test`
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_68526b28d6e88328ae5b88d0d992f3fa