### PR TITLE
Refactor screenshot helpers

### DIFF
--- a/apps/react/tests/helpers.ts
+++ b/apps/react/tests/helpers.ts
@@ -16,3 +16,15 @@ export const test = base.extend<{ page: Page }>({
 });
 
 export { expect };
+
+export async function captureScreenshot(
+	page: Page,
+	url: string,
+	name: string,
+	selector = '#output',
+) {
+	await page.goto(url);
+	const output = page.locator(selector);
+	await output.waitFor();
+	await expect(output).toHaveScreenshot(name, screenshotOpts);
+}

--- a/apps/react/tests/music-notation-eighth.spec.ts
+++ b/apps/react/tests/music-notation-eighth.spec.ts
@@ -1,8 +1,9 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, captureScreenshot } from './helpers';
 
 test('MusicNotation eighth notes screenshot', async ({ page }) => {
-	await page.goto('/tests/music-notation-eighth-test.html');
-	const output = page.locator('#output');
-	await output.waitFor();
-	await expect(output).toHaveScreenshot('music-notation-eighth.png', screenshotOpts);
+	await captureScreenshot(
+		page,
+		'/tests/music-notation-eighth-test.html',
+		'music-notation-eighth.png',
+	);
 });

--- a/apps/react/tests/music-notation-half-quarter.spec.ts
+++ b/apps/react/tests/music-notation-half-quarter.spec.ts
@@ -1,8 +1,9 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, captureScreenshot } from './helpers';
 
 test('MusicNotation half and quarter notes screenshot', async ({ page }) => {
-	await page.goto('/tests/music-notation-half-quarter-test.html');
-	const output = page.locator('#output');
-	await output.waitFor();
-	await expect(output).toHaveScreenshot('music-notation-half-quarter.png', screenshotOpts);
+	await captureScreenshot(
+		page,
+		'/tests/music-notation-half-quarter-test.html',
+		'music-notation-half-quarter.png',
+	);
 });

--- a/apps/react/tests/music-notation-highlight.spec.ts
+++ b/apps/react/tests/music-notation-highlight.spec.ts
@@ -1,12 +1,13 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, captureScreenshot } from './helpers';
 
 test.describe('highlight notes', () => {
 	for (const index of [1, 2, 3, 4]) {
 		test(`highlight note ${index}`, async ({ page }) => {
-			await page.goto(`/tests/music-notation-test.html?index=${index}`);
-			const output = page.locator('#output');
-			await output.waitFor();
-			await expect(output).toHaveScreenshot(`highlight-${index}.png`, screenshotOpts);
+			await captureScreenshot(
+				page,
+				`/tests/music-notation-test.html?index=${index}`,
+				`highlight-${index}.png`,
+			);
 		});
 	}
 });

--- a/apps/react/tests/music-notation-rest.spec.ts
+++ b/apps/react/tests/music-notation-rest.spec.ts
@@ -1,8 +1,9 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, captureScreenshot } from './helpers';
 
 test('MusicNotation rests screenshot', async ({ page }) => {
-	await page.goto('/tests/music-notation-rest-test.html');
-	const output = page.locator('#output');
-	await output.waitFor();
-	await expect(output).toHaveScreenshot('music-notation-rest.png', screenshotOpts);
+	await captureScreenshot(
+		page,
+		'/tests/music-notation-rest-test.html',
+		'music-notation-rest.png',
+	);
 });

--- a/apps/react/tests/music-notation.spec.ts
+++ b/apps/react/tests/music-notation.spec.ts
@@ -1,8 +1,5 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, captureScreenshot } from './helpers';
 
 test('MusicNotation component screenshot', async ({ page }) => {
-	await page.goto('/tests/music-notation-test.html');
-	const output = page.locator('#output');
-	await output.waitFor();
-	await expect(output).toHaveScreenshot('music-notation.png', screenshotOpts);
+	await captureScreenshot(page, '/tests/music-notation-test.html', 'music-notation.png');
 });


### PR DESCRIPTION
## Summary
- add `captureScreenshot` helper
- use new helper in several screenshot tests

## Testing
- `yarn test` *(fails: music notation screenshot comparisons)*
- `yarn workspace MemoryFlashReact build`

------
https://chatgpt.com/codex/tasks/task_e_68530dd09fe48328a7582209c5ebcbdc