### PR TITLE
Add MusicNotation bass clef spec

### DIFF
--- a/apps/react/tests/music-notation-bass-test.html
+++ b/apps/react/tests/music-notation-bass-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicNotation Bass Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/music-notation-bass-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/music-notation-bass-test.tsx
+++ b/apps/react/tests/music-notation-bass-test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+import { renderApp } from './renderApp';
+
+const data: MultiSheetQuestion = {
+	key: 'C',
+	voices: [
+		{
+			staff: StaffEnum.Bass,
+			stack: [
+				{ notes: [{ name: 'C', octave: 2 }], duration: 'q' },
+				{ notes: [{ name: 'D', octave: 2 }], duration: 'q' },
+				{ notes: [{ name: 'E', octave: 2 }], duration: 'q' },
+				{ notes: [{ name: 'F', octave: 2 }], duration: 'q' },
+			],
+		},
+	],
+};
+
+renderApp(<MusicNotation data={data} highlightClassName="highlight" />);

--- a/apps/react/tests/music-notation-bass.spec.ts
+++ b/apps/react/tests/music-notation-bass.spec.ts
@@ -1,0 +1,9 @@
+import { test, captureScreenshot } from './helpers';
+
+test('MusicNotation bass clef screenshot', async ({ page }) => {
+	await captureScreenshot(
+		page,
+		'/tests/music-notation-bass-test.html',
+		'music-notation-bass.png',
+	);
+});


### PR DESCRIPTION
## Summary
- add bass clef Playwright spec
- add test page
- add React test harness

## Testing
- `yarn workspace MemoryFlashReact build`
- `yarn test` *(fails: new screenshots)*

------
https://chatgpt.com/codex/tasks/task_e_6853114fd3508328b3f6fe47b1ab25b5