### PR TITLE
Fix cross-staff rest handling in notation builder

### DIFF
--- a/apps/react/tests/music-recorder-cross-clef-test.html
+++ b/apps/react/tests/music-recorder-cross-clef-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicRecorder Cross Clef Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/music-recorder-cross-clef-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/music-recorder-cross-clef-test.tsx
+++ b/apps/react/tests/music-recorder-cross-clef-test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MusicRecorder } from 'MemoryFlashCore/src/lib/MusicRecorder';
+import { renderApp } from './renderApp';
+
+const recorder = new MusicRecorder('q');
+(window as any).recorder = recorder;
+
+const App: React.FC = () => {
+	const [data, setData] = React.useState(recorder.buildQuestion('C'));
+
+	React.useEffect(() => {
+		(window as any).update = () => setData(recorder.buildQuestion('C'));
+	}, []);
+
+	return <MusicNotation data={data} />;
+};
+
+renderApp(<App />);

--- a/apps/react/tests/music-recorder-cross-clef.spec.ts
+++ b/apps/react/tests/music-recorder-cross-clef.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect, screenshotOpts } from './helpers';
+
+test('MusicRecorder cross-clef rests', async ({ page }) => {
+	await page.goto('/tests/music-recorder-cross-clef-test.html');
+	const output = page.locator('#output');
+	const events = [[60], [], [48], [], [60], [], [48], []];
+
+	for (let i = 0; i < events.length; i++) {
+		await page.evaluate((notes) => {
+			(window as any).recorder.addMidiNotes(notes);
+			(window as any).update();
+		}, events[i]);
+		await output.waitFor();
+		await expect(output).toHaveScreenshot(
+			`music-recorder-cross-clef-${i + 1}.png`,
+			screenshotOpts,
+		);
+	}
+});

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { MusicRecorder } from './MusicRecorder';
+import { StaffEnum } from '../types/Cards';
 
 describe('MusicRecorder', () => {
 	it('converts midi numbers to sheet notes', () => {
@@ -75,5 +76,24 @@ describe('MusicRecorder', () => {
 				duration: 'q',
 			},
 		]);
+	});
+
+	it('adds rests to the opposite clef when alternating notes', () => {
+		const r = new MusicRecorder('q');
+		r.addMidiNotes([60]);
+		r.addMidiNotes([]);
+		r.addMidiNotes([48]);
+		r.addMidiNotes([]);
+		r.addMidiNotes([60]);
+		r.addMidiNotes([]);
+		r.addMidiNotes([48]);
+		r.addMidiNotes([]);
+
+		const q = r.buildQuestion('C');
+		const treble = q.voices.find((v) => v.staff === StaffEnum.Treble)!.stack;
+		const bass = q.voices.find((v) => v.staff === StaffEnum.Bass)!.stack;
+
+		expect(treble.map((n) => n.rest || false)).to.deep.equal([false, true, false, true]);
+		expect(bass.map((n) => n.rest || false)).to.deep.equal([true, false, true, false]);
 	});
 });

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -1,4 +1,4 @@
-import { Midi } from 'tonal';
+import { Midi, Note } from 'tonal';
 import { MultiSheetQuestion, StackedNotes, NoteDuration } from '../types/MultiSheetCard';
 import { StaffEnum } from '../types/Cards';
 import { buildMultiSheetQuestion } from './notationBuilder';
@@ -9,7 +9,10 @@ export class MusicRecorder {
 	private _maxBeats = 4;
 	private prevMidiNotes: number[] = [];
 
-	constructor(public duration: NoteDuration = 'q') {}
+	constructor(
+		public duration: NoteDuration = 'q',
+		public splitNote = 'C4',
+	) {}
 
 	updateDuration(dur: NoteDuration) {
 		this.duration = dur;
@@ -74,7 +77,8 @@ export class MusicRecorder {
 		}
 
 		// Split notes by staff, then fill rests per voice separately
-		const { voices } = buildMultiSheetQuestion(this.notes, key);
+		const splitMidi = Note.midi(this.splitNote)!;
+		const { voices } = buildMultiSheetQuestion(this.notes, key, splitMidi);
 		const filledVoices = voices.map((v) => ({
 			...v,
 			stack: insertRestsToFillBars(v.stack),

--- a/packages/MemoryFlashCore/src/lib/notationBuilder.ts
+++ b/packages/MemoryFlashCore/src/lib/notationBuilder.ts
@@ -1,16 +1,44 @@
 import { StaffEnum } from '../types/Cards';
 import { MultiSheetQuestion, StackedNotes, Voice } from '../types/MultiSheetCard';
+import { Note } from 'tonal';
 
-export function buildMultiSheetQuestion(notes: StackedNotes[], key: string): MultiSheetQuestion {
+export function buildMultiSheetQuestion(
+	notes: StackedNotes[],
+	key: string,
+	splitMidi: number = Note.midi('C4')!,
+): MultiSheetQuestion {
+	const toMidi = (note: { name: string; octave: number }) =>
+		Note.midi(`${note.name}${note.octave}`)!;
+
+	const trebleVisible = notes.some((n) => n.notes.some((note) => toMidi(note) >= splitMidi));
+	const bassVisible = notes.some((n) => n.notes.some((note) => toMidi(note) < splitMidi));
+
 	const treble: StackedNotes[] = [];
 	const bass: StackedNotes[] = [];
+
 	for (const n of notes) {
-		const octave = n.notes[0]?.octave ?? 0;
-		if (octave >= 4) treble.push(n);
-		else bass.push(n);
+		const trebleNotes = n.notes.filter((note) => toMidi(note) >= splitMidi);
+		const bassNotes = n.notes.filter((note) => toMidi(note) < splitMidi);
+
+		if (trebleVisible) {
+			if (trebleNotes.length) {
+				treble.push({ ...n, notes: trebleNotes });
+			} else {
+				treble.push({ notes: [], duration: n.duration, rest: true });
+			}
+		}
+
+		if (bassVisible) {
+			if (bassNotes.length) {
+				bass.push({ ...n, notes: bassNotes });
+			} else {
+				bass.push({ notes: [], duration: n.duration, rest: true });
+			}
+		}
 	}
+
 	const voices: Voice[] = [];
-	if (treble.length) voices.push({ staff: StaffEnum.Treble, stack: treble });
-	if (bass.length) voices.push({ staff: StaffEnum.Bass, stack: bass });
+	if (trebleVisible) voices.push({ staff: StaffEnum.Treble, stack: treble });
+	if (bassVisible) voices.push({ staff: StaffEnum.Bass, stack: bass });
 	return { key, voices };
 }


### PR DESCRIPTION
## Summary
- ensure empty beats are mirrored to the opposite clef when building multi-sheet questions
- cover cross-clef rest behaviour in `MusicRecorder` tests
- add Playwright test for cross-clef rests

## Testing
- `yarn test` *(fails: MusicNotation screenshots)*
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_685312ecfd00832888f97d1a59c4c172