### PR TITLE
Fix sorting for test failure report

### DIFF
--- a/scripts/report-test-failure.sh
+++ b/scripts/report-test-failure.sh
@@ -78,7 +78,8 @@ while IFS= read -r -d '' f; do
 done < <(find apps/react/tests -name '*.png' -print0)
 
 # Render per-test table in rows with images in second column
-for prefix in "${!actual_paths[@]}"; do
+readarray -t sorted_prefixes < <(printf '%s\n' "${!actual_paths[@]}" | sort)
+for prefix in "${sorted_prefixes[@]}"; do
    actual_path="${actual_paths[$prefix]}"
    diff_path="${diff_paths[$prefix]:-}"
    expected_path="${expected_paths[$prefix]:-}"


### PR DESCRIPTION
## Summary
- sort failing tests alphabetically in the `report-test-failure.sh` output

## Testing
- `yarn test` *(fails: 7 failed)*
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_68531a3432c483289ea6558b0c9f82f7