### PR TITLE
Fix CardOptionsMenu UI

### DIFF
--- a/apps/react/src/components/Card.tsx
+++ b/apps/react/src/components/Card.tsx
@@ -14,7 +14,7 @@ export const Card: React.FC<CardProps> = ({
 	style,
 }) => {
 	return (
-		<div className={`overflow-hidden bg-white shadow sm:rounded-lg ${className}`}>
+		<div className={`overflow-visible bg-white shadow sm:rounded-lg ${className}`}>
 			<div
 				className={`px-4 py-5 sm:p-6 h-full flex flex-col ${contentContainerClassName}`}
 				style={style}

--- a/apps/react/src/components/CardOptionsMenu.tsx
+++ b/apps/react/src/components/CardOptionsMenu.tsx
@@ -1,6 +1,7 @@
 import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import React from 'react';
 import Dropdown from './Dropdown';
+import { CircleHover } from './CircleHover';
 import { InputModal } from './modals/InputModal';
 import { ConfirmModal } from './modals/ConfirmModal';
 
@@ -25,7 +26,12 @@ export const CardOptionsMenu: React.FC<CardOptionsMenuProps> = ({
 	return (
 		<>
 			<Dropdown
-				label={<EllipsisVerticalIcon className="w-5 h-5" />}
+				label={
+					<CircleHover>
+						<EllipsisVerticalIcon className="w-5 h-5" />
+					</CircleHover>
+				}
+				chevron={false}
 				items={[
 					{
 						label: 'Rename',

--- a/apps/react/src/components/Dropdown.tsx
+++ b/apps/react/src/components/Dropdown.tsx
@@ -11,13 +11,14 @@ interface DropdownProps {
 	label: React.ReactNode;
 	items: DropdownItem[];
 	onButtonClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined) => void;
+	chevron?: boolean;
 }
 
 function classNames(...classes: string[]) {
 	return classes.filter(Boolean).join(' ');
 }
 
-const Dropdown: React.FC<DropdownProps> = ({ label, items, onButtonClick }) => {
+const Dropdown: React.FC<DropdownProps> = ({ label, items, onButtonClick, chevron = true }) => {
 	return (
 		<Menu as="div" className="relative inline-block text-left">
 			<div>
@@ -26,7 +27,12 @@ const Dropdown: React.FC<DropdownProps> = ({ label, items, onButtonClick }) => {
 					className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
 				>
 					{label}
-					<ChevronDownIcon className="-mr-1 h-5 w-5 text-gray-400" aria-hidden="true" />
+					{chevron && (
+						<ChevronDownIcon
+							className="-mr-1 h-5 w-5 text-gray-400"
+							aria-hidden="true"
+						/>
+					)}
 				</MenuButton>
 			</div>
 			<Transition

--- a/apps/react/src/components/SectionCard.tsx
+++ b/apps/react/src/components/SectionCard.tsx
@@ -21,10 +21,14 @@ export const SectionCard: React.FC<SectionCardProps> = ({
 }) => {
 	return (
 		<Card
-			className={`w-44 h-44 ${className}`}
+			className={`w-44 h-44 group ${className}`}
 			contentContainerClassName="justify-between items-center relative"
 		>
-			{menu && <div className="absolute top-2 right-2">{menu}</div>}
+			{menu && (
+				<div className="absolute -top-2 -right-2 sm:opacity-0 sm:group-hover:opacity-100">
+					{menu}
+				</div>
+			)}
 			<div className="text-center">
 				<div className="text-sm font-medium">{title}</div>
 				{subTitle && <div className="text-[0.6rem]">{subTitle}</div>}


### PR DESCRIPTION
## Summary
- let Dropdown optionally hide the chevron
- show Card menu button outside the card corner and only on hover for desktop
- style CardOptionsMenu with CircleHover
- allow card overflow so dropdown menus are visible

## Testing
- `yarn test` *(fails: 7 failing tests)*
- `yarn workspace MemoryFlashReact build`

------
https://chatgpt.com/codex/tasks/task_e_685319c307b88328b5ee292e18aade64