### PR TITLE
Add LLM diff screenshot workflow

### DIFF
--- a/.github/scripts/captureScreenshots.ts
+++ b/.github/scripts/captureScreenshots.ts
@@ -1,0 +1,146 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { chromium } from 'playwright';
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+interface BaseStep {
+	wait?: number;
+}
+
+interface GotoStep extends BaseStep {
+	action: 'goto';
+	url: string;
+}
+
+interface ClickStep extends BaseStep {
+	action: 'click';
+	selector: string;
+}
+
+interface FillStep extends BaseStep {
+	action: 'fill';
+	selector: string;
+	value?: string;
+}
+
+interface ScreenshotStep extends BaseStep {
+        action: 'screenshot';
+        name: string;
+}
+
+interface LoginStep extends BaseStep {
+        action: 'login';
+}
+
+type Step = GotoStep | ClickStep | FillStep | ScreenshotStep | LoginStep;
+
+async function loadCookies(page: any): Promise<void> {
+	const cookiePath = process.env.SESSION_COOKIES_PATH || 'test-fixtures/session-cookies.json';
+	try {
+		console.log(`Loading cookies from ${cookiePath}`);
+		const data = await fs.readFile(cookiePath, 'utf8');
+		const cookies = JSON.parse(data);
+		await page.context().addCookies(cookies);
+		console.log('Cookies added');
+	} catch {
+		// ignore if file missing
+	}
+}
+
+async function querySelectorFromLLM(html: string, desired: string): Promise<string | null> {
+	if (!OPENAI_API_KEY) return null;
+	try {
+		const res = await fetch('https://api.openai.com/v1/chat/completions', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${OPENAI_API_KEY}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				model: 'o4mini-high',
+				messages: [
+					{ role: 'system', content: 'Provide a CSS selector only.' },
+					{
+						role: 'user',
+						content: `HTML:\n${html}\n\nFind a selector for element described as "${desired}"`,
+					},
+				],
+			}),
+		});
+		const json = await res.json();
+		const text = json.choices?.[0]?.message?.content?.trim();
+		return text || null;
+	} catch (err) {
+		console.error('LLM error', err);
+		return null;
+	}
+}
+
+async function loadSteps(planPath: string): Promise<Step[]> {
+	console.log(`Reading plan from ${planPath}`);
+	const text = await fs.readFile(planPath, 'utf8');
+	const match = text.match(/```json\s*([\s\S]*?)\s*```/);
+	if (!match) {
+		throw new Error('No JSON block found in plan');
+	}
+	const steps = JSON.parse(match[1]) as Step[];
+	console.log('Loaded steps:', steps);
+	return steps;
+}
+
+async function run(): Promise<void> {
+	console.log('Starting screenshot capture');
+	const steps = await loadSteps('ui-plan.md');
+	const resultsDir = path.join('apps', 'react', 'test-results');
+	await fs.mkdir(resultsDir, { recursive: true });
+
+	console.log('Launching headless browser');
+        const browser = await chromium.launch();
+        const page = await browser.newPage();
+
+	for (const step of steps) {
+		console.log('Executing step', step);
+		try {
+                        if (step.action === 'goto') {
+                                await page.goto(step.url);
+                        } else if (step.action === 'click') {
+                                await page.click(step.selector);
+                        } else if (step.action === 'fill') {
+                                await page.fill(step.selector, step.value ?? '');
+                        } else if (step.action === 'login') {
+                                await loadCookies(page);
+                        } else if (step.action === 'screenshot') {
+                                const screenshotPath = path.join(resultsDir, step.name);
+                                console.log(`Capturing screenshot ${screenshotPath}`);
+                                await page.screenshot({ path: screenshotPath });
+			}
+		} catch (err) {
+			console.error('Error executing step', step, err);
+			if (step.action === 'click') {
+				const html = await page.content();
+				const newSelector = await querySelectorFromLLM(html, step.selector);
+				if (newSelector) {
+					console.log(`LLM suggested selector: ${newSelector}`);
+					await page.click(newSelector);
+				} else {
+					throw err;
+				}
+			} else {
+				throw err;
+			}
+		}
+		if (step.wait) {
+			await page.waitForTimeout(step.wait);
+		}
+		console.log('Completed step', step.action);
+	}
+
+	await browser.close();
+	console.log('Finished capturing screenshots');
+}
+
+run().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/.github/scripts/captureScreenshots.ts
+++ b/.github/scripts/captureScreenshots.ts
@@ -25,12 +25,12 @@ interface FillStep extends BaseStep {
 }
 
 interface ScreenshotStep extends BaseStep {
-        action: 'screenshot';
-        name: string;
+	action: 'screenshot';
+	name: string;
 }
 
 interface LoginStep extends BaseStep {
-        action: 'login';
+	action: 'login';
 }
 
 type Step = GotoStep | ClickStep | FillStep | ScreenshotStep | LoginStep;
@@ -96,24 +96,24 @@ async function run(): Promise<void> {
 	await fs.mkdir(resultsDir, { recursive: true });
 
 	console.log('Launching headless browser');
-        const browser = await chromium.launch();
-        const page = await browser.newPage();
+	const browser = await chromium.launch();
+	const page = await browser.newPage();
 
 	for (const step of steps) {
 		console.log('Executing step', step);
 		try {
-                        if (step.action === 'goto') {
-                                await page.goto(step.url);
-                        } else if (step.action === 'click') {
-                                await page.click(step.selector);
-                        } else if (step.action === 'fill') {
-                                await page.fill(step.selector, step.value ?? '');
-                        } else if (step.action === 'login') {
-                                await loadCookies(page);
-                        } else if (step.action === 'screenshot') {
-                                const screenshotPath = path.join(resultsDir, step.name);
-                                console.log(`Capturing screenshot ${screenshotPath}`);
-                                await page.screenshot({ path: screenshotPath });
+			if (step.action === 'goto') {
+				await page.goto(step.url);
+			} else if (step.action === 'click') {
+				await page.click(step.selector);
+			} else if (step.action === 'fill') {
+				await page.fill(step.selector, step.value ?? '');
+			} else if (step.action === 'login') {
+				await loadCookies(page);
+			} else if (step.action === 'screenshot') {
+				const screenshotPath = path.join(resultsDir, step.name);
+				console.log(`Capturing screenshot ${screenshotPath}`);
+				await page.screenshot({ path: screenshotPath });
 			}
 		} catch (err) {
 			console.error('Error executing step', step, err);

--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -1,0 +1,79 @@
+name: Diff-based UI Screenshots
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+    workflow_dispatch:
+
+jobs:
+    screenshots:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Enable Corepack
+              run: corepack enable
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 20.x
+                  cache: 'yarn'
+
+            - name: Install dependencies
+              run: yarn install
+
+            - name: Check for plan file
+              id: plan
+              run: |
+                  if [ -f ui-plan.md ]; then
+                    echo "exists=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "exists=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Build React app
+              if: steps.plan.outputs.exists == 'true'
+              run: yarn workspace MemoryFlashReact build
+
+            - name: Build server
+              if: steps.plan.outputs.exists == 'true'
+              run: yarn workspace MemoryFlashServer build
+
+            - name: Start MongoDB
+              if: steps.plan.outputs.exists == 'true'
+              uses: supercharge/mongodb-github-action@1.8.0
+              with:
+                  mongodb-version: '6.0'
+
+            - name: Start app servers
+              if: steps.plan.outputs.exists == 'true'
+              env:
+                  MONGO_URI: mongodb://localhost:27017/memoryflash
+                  APP_URL: http://localhost:8009
+                  FRONT_END_URL: http://localhost:8009
+              run: |
+                  yarn workspace MemoryFlashServer start:prod &
+                  yarn workspace MemoryFlashReact preview --port 8009 &
+                  timeout 60 bash -c 'until nc -z localhost 8009; do sleep 2; done'
+                  timeout 60 bash -c 'until nc -z localhost 3000; do sleep 2; done'
+
+            - name: Capture screenshots
+              if: steps.plan.outputs.exists == 'true'
+              run: node --loader ts-node/esm .github/scripts/captureScreenshots.ts
+
+            - name: Authenticate on GCS
+              if: steps.plan.outputs.exists == 'true'
+              uses: google-github-actions/auth@v2
+              with:
+                  credentials_json: ${{ secrets.GCP_MFLASH_PROD_JSON_KEY }}
+
+            - name: Upload screenshots and comment
+              if: steps.plan.outputs.exists == 'true'
+              run: ./scripts/report-test-failure.sh
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ apps/MemoryFlashServer/.gitignore.swp
 apps/ios/MemoryFlashiOS.xcodeproj/xcuserdata/sam.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
 apps/ios/MemoryFlashiOS.xcodeproj/project.xcworkspace/xcuserdata/sam.xcuserdatad/UserInterfaceState.xcuserstate
 *.tsbuildinfo
+test-fixtures/session-cookies.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,34 @@
 
 This project prefers a highly componentized React codebase. When creating UI elements:
 
-- **Componentization**: Extract reusable JSX into components whenever possible. Keep components small and focused.
-- **File Organization**: Group related components together in folders (e.g., all input components live in `components/inputs`).
-- **Styling**: Use Tailwind CSS utility classes. Share common styling through base components rather than repeating class strings.
-- **Formatting**: Code is formatted with Prettier using tabs. Run `npx prettier --write` before committing if available. No comments in Swift files.
-- **Testing**: After changes, run `yarn test` from the repository root.
-- **Type Checking**: Run `yarn workspace MemoryFlashReact build` to ensure there are no missing imports or type errors.
-- **Screenshots**: When adding new Playwright `.spec.ts` files, delete any generated `.png` snapshots before committing. Maintainers will upload them separately.
+-   **Componentization**: Extract reusable JSX into components whenever possible. Keep components small and focused.
+-   **File Organization**: Group related components together in folders (e.g., all input components live in `components/inputs`).
+-   **Styling**: Use Tailwind CSS utility classes. Share common styling through base components rather than repeating class strings.
+-   **Formatting**: Code is formatted with Prettier using tabs. Run `npx prettier --write` before committing if available. No comments in Swift files.
+-   **Testing**: After changes, run `yarn test` from the repository root.
+-   **Type Checking**: Run `yarn workspace MemoryFlashReact build` to ensure there are no missing imports or type errors.
+-   **Screenshots**: When adding new Playwright `.spec.ts` files, delete any generated `.png` snapshots before committing. Maintainers will upload them separately.
 
 Follow these guidelines to keep the codebase clean and maintainable.
 
 For the iOS project, do not add comments to Swift source files. Keep the code
 self-explanatory.
+
+## LLM Screenshot Workflow
+
+When you want Codex to capture UI screenshots, instruct it to create a file named `ui-plan.md` at the repository root. Codex should consider the UI changes it introduced and write a Markdown plan describing how to navigate to the updated screens. The plan must include a fenced `json` block listing the steps for Playwright to execute.
+
+Example plan format:
+
+```json
+[
+	{ "action": "goto", "url": "/" },
+	{ "action": "screenshot", "name": "home.png" },
+	{ "action": "click", "selector": "text=Login" },
+	{ "action": "screenshot", "name": "login.png" }
+]
+```
+
+When `ui-plan.md` exists, the workflow `.github/workflows/ui-screenshots.yml` will build the app, run `ts-node` on `.github/scripts/captureScreenshots.ts`, and upload the resulting screenshots to the pull request.
+
+The screenshot runner looks for a standard login fixture at `test-fixtures/session-cookies.json`. Include a `{"action": "login"}` step in your plan and the runner will inject these cookies automatically. If any selector in the plan fails, the runner queries the `o4mini-high` model with the current page HTML to guess an updated selector.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,13 @@
 
 This project prefers a highly componentized React codebase. When creating UI elements:
 
--   **Componentization**: Extract reusable JSX into components whenever possible. Keep components small and focused.
--   **File Organization**: Group related components together in folders (e.g., all input components live in `components/inputs`).
--   **Styling**: Use Tailwind CSS utility classes. Share common styling through base components rather than repeating class strings.
--   **Formatting**: Code is formatted with Prettier using tabs. Run `npx prettier --write` before committing if available. No comments in Swift files.
--   **Testing**: After changes, run `yarn test` from the repository root.
--   **Type Checking**: Run `yarn workspace MemoryFlashReact build` to ensure there are no missing imports or type errors.
--   **Screenshots**: When adding new Playwright `.spec.ts` files, delete any generated `.png` snapshots before committing. Maintainers will upload them separately.
+- **Componentization**: Extract reusable JSX into components whenever possible. Keep components small and focused.
+- **File Organization**: Group related components together in folders (e.g., all input components live in `components/inputs`).
+- **Styling**: Use Tailwind CSS utility classes. Share common styling through base components rather than repeating class strings.
+- **Formatting**: Code is formatted with Prettier using tabs. Run `npx prettier --write` before committing if available. No comments in Swift files.
+- **Testing**: After changes, run `yarn test` from the repository root.
+- **Type Checking**: Run `yarn workspace MemoryFlashReact build` to ensure there are no missing imports or type errors.
+- **Screenshots**: When adding new Playwright `.spec.ts` files, delete any generated `.png` snapshots before committing. Maintainers will upload them separately.
 
 Follow these guidelines to keep the codebase clean and maintainable.
 

--- a/test-fixtures/session-cookies.example.json
+++ b/test-fixtures/session-cookies.example.json
@@ -1,0 +1,10 @@
+[
+	{
+		"name": "sid",
+		"value": "SESSION_ID",
+		"domain": "localhost",
+		"path": "/",
+		"httpOnly": true,
+		"secure": false
+	}
+]

--- a/ui-plan.md
+++ b/ui-plan.md
@@ -1,0 +1,9 @@
+# Sample UI plan
+
+```json
+[
+        { "action": "goto", "url": "http://localhost:8009" },
+        { "action": "login" },
+        { "action": "screenshot", "name": "home.png" }
+]
+```

--- a/ui-plan.md
+++ b/ui-plan.md
@@ -2,8 +2,8 @@
 
 ```json
 [
-        { "action": "goto", "url": "http://localhost:8009" },
-        { "action": "login" },
-        { "action": "screenshot", "name": "home.png" }
+	{ "action": "goto", "url": "http://localhost:8009" },
+	{ "action": "login" },
+	{ "action": "screenshot", "name": "home.png" }
 ]
 ```


### PR DESCRIPTION
## Summary
- document session cookie usage and LLM fallback in `AGENTS.md`
- add example auth cookie fixture and ignore real cookie file
- start Mongo, server, and preview in screenshot workflow
- enhance screenshot runner with optional cookie injection and LLM selector fixes
- add sample `ui-plan.md` and debug logging to screenshot runner
- update plan instructions and login handling

## Testing
- `yarn test` *(fails: screenshot diffs)*
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_685330daf3988328a63c4f309696391e