### PR TITLE
Allow multi-bar music recording

### DIFF
--- a/apps/react/src/components/MusicNotation.tsx
+++ b/apps/react/src/components/MusicNotation.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Stave, Vex, Note as VFNote } from 'vexflow';
 import { MultiSheetQuestion, Voice } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { calcBars } from 'MemoryFlashCore/src/lib/calcBars';
 import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
 import { Chord } from 'tonal';
 import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
@@ -20,7 +21,8 @@ const setupRendererAndStave = (div: HTMLDivElement, data: MultiSheetQuestion) =>
 
 	const renderer = new VF.Renderer(div, VF.Renderer.Backends.SVG);
 	const context = renderer.getContext();
-	const width = 370;
+	const bars = calcBars(data);
+	const width = 370 + (bars - 1) * 300;
 	const height = treble && bass ? 250 : 160;
 
 	renderer.resize(width + 2, height);
@@ -130,7 +132,7 @@ export const MusicNotation: React.FunctionComponent<MusicNotationProps> = ({
 		const div = divRef.current;
 		if (!div) return;
 		div.innerHTML = '';
-
+		const bars = calcBars(data);
 		const { bassStave, trebleStave, context } = setupRendererAndStave(div, data);
 		const topStave = trebleStave || bassStave!;
 
@@ -148,7 +150,9 @@ export const MusicNotation: React.FunctionComponent<MusicNotationProps> = ({
 				data._8va,
 			);
 			vfNotes.push(notes);
-			const vfVoice = new VF.Voice({ num_beats: 4, beat_value: 4 }).addTickables(notes);
+			const vfVoice = new VF.Voice({ num_beats: bars * 4, beat_value: 4 }).addTickables(
+				notes,
+			);
 
 			VF.Accidental.applyAccidentals([vfVoice], data.key);
 
@@ -171,7 +175,9 @@ export const MusicNotation: React.FunctionComponent<MusicNotationProps> = ({
 
 		if (!hideChords) {
 			const textNotes = createTextNotes(data, topStave);
-			const textVoice = new VF.Voice({ num_beats: 4, beat_value: 4 }).addTickables(textNotes);
+			const textVoice = new VF.Voice({ num_beats: bars * 4, beat_value: 4 }).addTickables(
+				textNotes,
+			);
 			formatter.joinVoices([textVoice]);
 			vfVoices.push(textVoice);
 		}

--- a/apps/react/src/components/inputs/NumberInput.tsx
+++ b/apps/react/src/components/inputs/NumberInput.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { BaseInput, BaseInputProps } from './BaseInput';
+
+export const NumberInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref) => (
+	<BaseInput type="number" ref={ref} {...props} />
+));
+NumberInput.displayName = 'NumberInput';

--- a/apps/react/src/components/inputs/index.ts
+++ b/apps/react/src/components/inputs/index.ts
@@ -5,3 +5,4 @@ export * from './PasswordInput';
 export * from './Select';
 export * from './Checkbox';
 export * from './DurationSelect';
+export * from './NumberInput';

--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store'
 import { MusicRecorder } from 'MemoryFlashCore/src/lib/MusicRecorder';
 import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
 import { Select, DurationSelect } from '../components/inputs';
+import { NumberInput } from '../components/inputs';
 import { questionsForAllMajorKeys } from 'MemoryFlashCore/src/lib/multiKeyTransposer';
 import { addCardsToDeck } from 'MemoryFlashCore/src/redux/actions/add-cards-to-deck';
 import { Button } from '../components/Button';
@@ -75,18 +76,36 @@ const RangeSettings: React.FC<{
 	);
 };
 
+const BarsSetting: React.FC<{ bars: number; setBars: (n: number) => void }> = ({
+	bars,
+	setBars,
+}) => (
+	<div className="pb-4">
+		<label className="flex items-center gap-2">
+			Bars
+			<NumberInput
+				className="w-16"
+				min={1}
+				value={bars}
+				onChange={(e) => setBars(parseInt(e.target.value, 10) || 1)}
+			/>
+		</label>
+	</div>
+);
+
 export const NotationInputScreen = () => {
 	const [keySig, setKeySig] = useState(majorKeys[0]);
 	const [trebleDur, setTrebleDur] = useState<NoteDuration>('q');
 	const [bassDur, setBassDur] = useState<NoteDuration>('q');
 	const [lowest, setLowest] = useState('C3');
 	const [highest, setHighest] = useState('C5');
+	const [bars, setBars] = useState(1);
 	const [selected, setSelected] = useState<boolean[]>(() => majorKeys.map(() => true));
 
 	const dispatch = useAppDispatch();
 	const { deckId } = useDeckIdPath();
 
-	const recorderRef = useRef(new MusicRecorder('q'));
+	const recorderRef = useRef(new MusicRecorder('q', 'C4', 'q', bars));
 	const midiNotes = useAppSelector(
 		(state) => state.midi.notes.map((n) => n.number),
 		shallowEqual,
@@ -99,6 +118,11 @@ export const NotationInputScreen = () => {
 	useEffect(() => {
 		recorderRef.current.updateDuration(bassDur, StaffEnum.Bass);
 	}, [bassDur]);
+
+	useEffect(() => {
+		recorderRef.current.setBars(bars);
+		recorderRef.current.reset();
+	}, [bars]);
 
 	useEffect(() => {
 		recorderRef.current.addMidiNotes(midiNotes);
@@ -131,6 +155,7 @@ export const NotationInputScreen = () => {
 				highest={highest}
 				setHighest={setHighest}
 			/>
+			<BarsSetting bars={bars} setBars={setBars} />
 			<div className="flex flex-col items-center gap-5">
 				{previews.map((p, i) => (
 					<label key={i} className="flex flex-col items-center gap-2">

--- a/apps/react/tests/music-recorder-two-measures-test.html
+++ b/apps/react/tests/music-recorder-two-measures-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicRecorder Two Measures Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/music-recorder-two-measures-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/music-recorder-two-measures-test.tsx
+++ b/apps/react/tests/music-recorder-two-measures-test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MusicRecorder } from 'MemoryFlashCore/src/lib/MusicRecorder';
+import { renderApp } from './renderApp';
+
+const recorder = new MusicRecorder('q', 'C4', 'q', 2);
+(window as any).recorder = recorder;
+
+const App: React.FC = () => {
+	const [data, setData] = React.useState(recorder.buildQuestion('C'));
+
+	React.useEffect(() => {
+		(window as any).update = () => setData(recorder.buildQuestion('C'));
+	}, []);
+
+	return <MusicNotation data={data} />;
+};
+
+renderApp(<App />);

--- a/apps/react/tests/music-recorder-two-measures.spec.ts
+++ b/apps/react/tests/music-recorder-two-measures.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect, screenshotOpts } from './helpers';
+
+test('MusicRecorder two measures screenshot', async ({ page }) => {
+	await page.goto('/tests/music-recorder-two-measures-test.html');
+	const output = page.locator('#output');
+	const events = [60, 62, 64, 65, 67, 69, 71, 72, 74];
+	for (const m of events) {
+		await page.evaluate((n) => {
+			(window as any).recorder.addMidiNotes([n]);
+			(window as any).update();
+		}, m);
+		await page.evaluate(() => {
+			(window as any).recorder.addMidiNotes([]);
+			(window as any).update();
+		});
+	}
+	await output.waitFor();
+	await expect(output).toHaveScreenshot('music-recorder-two-measures.png', screenshotOpts);
+});

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
@@ -31,6 +31,24 @@ describe('MusicRecorder', () => {
 		expect(r.notes.length).to.equal(4);
 	});
 
+	it('records two measures when configured', () => {
+		const r = new MusicRecorder('q', 'C4', 'q', 2);
+		for (const n of [60, 62, 64, 65, 67, 69, 71, 72]) {
+			r.addMidiNotes([n]);
+			r.addMidiNotes([]);
+		}
+		expect(r.notes.length).to.equal(8);
+	});
+
+	it('ignores notes beyond two measures', () => {
+		const r = new MusicRecorder('q', 'C4', 'q', 2);
+		for (const n of [60, 62, 64, 65, 67, 69, 71, 72, 74]) {
+			r.addMidiNotes([n]);
+			r.addMidiNotes([]);
+		}
+		expect(r.notes.length).to.equal(8);
+	});
+
 	it('records new stack only after notes released', () => {
 		const r = new MusicRecorder('q');
 		r.addMidiNotes([60]);

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -22,6 +22,7 @@ export class MusicRecorder {
 	public splitNote: string;
 
 	private _maxBeats = 4;
+	private bars = 1;
 	private prevMidiNotes: number[] = [];
 	private currentBeat = 0;
 	private staff: Record<StaffKey, StaffState>;
@@ -30,12 +31,19 @@ export class MusicRecorder {
 		trebleDuration: NoteDuration = 'q',
 		splitNote = 'C4',
 		bassDuration: NoteDuration = 'q',
+		bars = 1,
 	) {
 		this.splitNote = splitNote;
+		this.setBars(bars);
 		this.staff = {
 			[StaffEnum.Treble]: { events: [], beats: 0, duration: trebleDuration },
 			[StaffEnum.Bass]: { events: [], beats: 0, duration: bassDuration },
 		};
+	}
+
+	setBars(bars: number): void {
+		this.bars = bars;
+		this._maxBeats = bars * 4;
 	}
 
 	updateDuration(dur: NoteDuration, staff?: StaffEnum): void {

--- a/packages/MemoryFlashCore/src/lib/calcBars.ts
+++ b/packages/MemoryFlashCore/src/lib/calcBars.ts
@@ -1,0 +1,10 @@
+import { MultiSheetQuestion } from '../types/MultiSheetCard';
+import { durationBeats } from './measure';
+
+export function calcBars(data: MultiSheetQuestion): number {
+	const beats = data.voices.map((v) =>
+		v.stack.reduce((sum, n) => sum + durationBeats[n.duration], 0),
+	);
+	const max = Math.max(...beats, 0);
+	return Math.max(1, Math.ceil(max / 4));
+}


### PR DESCRIPTION
## Summary
- configure MusicRecorder for multiple bars via setBars
- adjust stave width for extra bars in MusicNotation
- update NotationInputScreen to set and reset bar count
- factor calcBars helper into MemoryFlashCore

## Testing
- `yarn test` *(fails: music-notation-bass.spec.ts, music-notation-half-quarter.spec.ts, music-notation-highlight.spec.ts, music-notation.spec.ts, music-recorder-two-measures.spec.ts, notation-input-screen.spec.ts)*
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_6853c011741883288b56265c16043abd