### PR TITLE
Update screenshot plan to get to courses screen

### DIFF
--- a/ui-plan.md
+++ b/ui-plan.md
@@ -2,9 +2,9 @@
 
 ```json
 [
-        { "action": "goto", "url": "http://localhost:8009" },
-        { "action": "login" },
-        { "action": "goto", "url": "http://localhost:8009" },
-        { "action": "screenshot", "name": "courses.png" }
+	{ "action": "goto", "url": "http://localhost:8009" },
+	{ "action": "login" },
+	{ "action": "goto", "url": "http://localhost:8009" },
+	{ "action": "screenshot", "name": "courses.png" }
 ]
 ```

--- a/ui-plan.md
+++ b/ui-plan.md
@@ -2,8 +2,9 @@
 
 ```json
 [
-	{ "action": "goto", "url": "http://localhost:8009" },
-	{ "action": "login" },
-	{ "action": "screenshot", "name": "home.png" }
+        { "action": "goto", "url": "http://localhost:8009" },
+        { "action": "login" },
+        { "action": "goto", "url": "http://localhost:8009" },
+        { "action": "screenshot", "name": "courses.png" }
 ]
 ```


### PR DESCRIPTION
## Summary
- reload the root URL after cookies are injected so Playwright lands on the Courses screen

## Testing
- `yarn test` *(fails: MusicNotation screenshot tests)*
- `yarn workspace MemoryFlashReact build`


------
https://chatgpt.com/codex/tasks/task_e_6853cd6f320883288f881b7b92bfe790