### PR TITLE
Add key selector on NotationInputScreen

### DIFF
--- a/apps/react/src/components/KeySelector.tsx
+++ b/apps/react/src/components/KeySelector.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { majorKeys } from 'MemoryFlashCore/src/lib/notes';
+import { Checkbox } from './inputs';
+
+interface KeySelectorProps {
+	selected: boolean[];
+	toggle: (i: number) => void;
+	selectAll: () => void;
+	selectNone: () => void;
+}
+
+export const KeySelector: React.FC<KeySelectorProps> = ({
+	selected,
+	toggle,
+	selectAll,
+	selectNone,
+}) => {
+	return (
+		<div className="flex flex-col gap-2 pb-4 items-start">
+			<div className="flex gap-2 text-sm">
+				<button type="button" onClick={selectAll} className="underline text-blue-600">
+					All
+				</button>
+				<button type="button" onClick={selectNone} className="underline text-blue-600">
+					None
+				</button>
+			</div>
+			<div className="grid grid-cols-4 gap-2">
+				{majorKeys.map((k, i) => (
+					<label key={k} className="flex items-center gap-1">
+						<Checkbox checked={selected[i]} onChange={() => toggle(i)} />
+						<span>{k}</span>
+					</label>
+				))}
+			</div>
+		</div>
+	);
+};

--- a/apps/react/src/components/index.ts
+++ b/apps/react/src/components/index.ts
@@ -14,3 +14,4 @@ export * from './modals/InputModal';
 export * from './modals/ConfirmModal';
 export * from './CardOptionsMenu';
 export * from './ConsoleErrorsButton';
+export * from './KeySelector';

--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -14,7 +14,7 @@ import { addCardsToDeck } from 'MemoryFlashCore/src/redux/actions/add-cards-to-d
 import { setPresentationMode } from 'MemoryFlashCore/src/redux/actions/set-presentation-mode';
 import { CardTypeEnum } from 'MemoryFlashCore/src/types/Cards';
 import { Button } from '../components/Button';
-import { Checkbox } from '../components/inputs';
+import { KeySelector } from '../components/KeySelector';
 import { useDeckIdPath } from './useDeckIdPath';
 
 const NoteSettings: React.FC<{
@@ -112,6 +112,8 @@ export const NotationInputScreen = () => {
 	const data = recorderRef.current.buildQuestion(keySig);
 	const previews = questionsForAllMajorKeys(data, lowest, highest);
 	const toggle = (i: number) => setSelected((prev) => prev.map((v, idx) => (idx === i ? !v : v)));
+	const selectAll = () => setSelected(majorKeys.map(() => true));
+	const selectNone = () => setSelected(majorKeys.map(() => false));
 
 	const handleAdd = () => {
 		if (deckId) {
@@ -143,6 +145,12 @@ export const NotationInputScreen = () => {
 				highest={highest}
 				setHighest={setHighest}
 			/>
+			<KeySelector
+				selected={selected}
+				toggle={toggle}
+				selectAll={selectAll}
+				selectNone={selectNone}
+			/>
 			<div className="flex flex-col gap-4 pb-4 items-start">
 				<div className="flex items-center gap-2">
 					<span>Card Type</span>
@@ -159,17 +167,12 @@ export const NotationInputScreen = () => {
 			</div>
 			<div className="flex flex-col items-center gap-5">
 				{previews.map((p, i) => (
-					<label key={i} className="flex flex-col items-center gap-2">
+					<div key={i} className="flex flex-col items-center gap-2">
 						<div className="card-container flex flex-col items-center gap-2 w-[26rem]">
-							<div className="flex items-center gap-2">
-								<Checkbox checked={selected[i]} onChange={() => toggle(i)} />
-								<span className="text-gray-900 dark:text-gray-100">
-									{majorKeys[i]}
-								</span>
-							</div>
+							<span className="text-gray-900 dark:text-gray-100">{majorKeys[i]}</span>
 							<MusicNotation data={p} />
 						</div>
-					</label>
+					</div>
 				))}
 			</div>
 			<div className="pt-4 flex justify-center">


### PR DESCRIPTION
## Summary
- centralize major key selection with new `KeySelector` component
- export `KeySelector`
- update `NotationInputScreen` to use new component and move checkboxes out of previews

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_685469919dbc8328a50c67fbec4172bd