### PR TITLE
Fix screenshot scroll issue

### DIFF
--- a/apps/react/tests/notation-input-text-prompt.spec.ts
+++ b/apps/react/tests/notation-input-text-prompt.spec.ts
@@ -17,6 +17,7 @@ test('NotationInputScreen text prompt card type', async ({ page }) => {
 	await page.getByRole('menuitem', { name: 'Text Prompt' }).click();
 	await page.fill('#text-prompt', 'Hotel California verse');
 	await page.waitForTimeout(200);
+	await page.evaluate(() => window.scrollTo(0, 0));
 
 	expect(errors).toEqual([]);
 	await expect(output).toHaveScreenshot('notation-input-text-prompt.png', screenshotOpts);


### PR DESCRIPTION
## Summary
- ensure page scroll is reset before capturing NotationInput screenshot

## Testing
- `yarn test:codex`
- `yarn workspace MemoryFlashReact test:screenshots` *(fails: 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68546e1dcd188328a555c364e798a336