### PR TITLE
Centralize script constants

### DIFF
--- a/.github/scripts/captureScreenshots.ts
+++ b/.github/scripts/captureScreenshots.ts
@@ -2,8 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { chromium } from 'playwright';
 import { login } from './login';
-
-const repoRoot = path.resolve(__dirname, '..', '..');
+import { repoRoot } from './constants';
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 

--- a/.github/scripts/constants.ts
+++ b/.github/scripts/constants.ts
@@ -1,0 +1,10 @@
+import * as path from 'path';
+
+export const repoRoot = path.resolve(__dirname, '..', '..');
+
+export const DEFAULT_SERVER_URL = 'http://localhost:3333';
+export const DEFAULT_FRONT_END_URL = 'http://localhost:8009';
+export const DEFAULT_EMAIL = 'sam@riker.tech';
+export const DEFAULT_PASSWORD = 'Testing1!';
+export const DEFAULT_FIRST_NAME = 'Sam';
+export const DEFAULT_LAST_NAME = 'Bender';

--- a/.github/scripts/login.ts
+++ b/.github/scripts/login.ts
@@ -1,8 +1,15 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { Page } from 'playwright';
-
-const repoRoot = path.resolve(__dirname, '..', '..');
+import {
+	repoRoot,
+	DEFAULT_SERVER_URL,
+	DEFAULT_FRONT_END_URL,
+	DEFAULT_EMAIL,
+	DEFAULT_PASSWORD,
+	DEFAULT_FIRST_NAME,
+	DEFAULT_LAST_NAME,
+} from './constants';
 
 export async function login(page: Page): Promise<void> {
 	const cookiePath =
@@ -18,18 +25,19 @@ export async function login(page: Page): Promise<void> {
 		console.log('No cookies file, performing fresh login');
 	}
 
-	const serverUrl = process.env.SERVER_URL || 'http://localhost:3333';
-	const domain = new URL(serverUrl).hostname;
-	const email = process.env.TEST_EMAIL || 'sam@riker.tech';
-	const password = process.env.TEST_PASSWORD || 'Testing1!';
-	const firstName = process.env.TEST_FIRST_NAME || 'Sam';
-	const lastName = process.env.TEST_LAST_NAME || 'Bender';
+	const serverUrl = process.env.SERVER_URL || DEFAULT_SERVER_URL;
+	const frontEndUrl = process.env.FRONT_END_URL || process.env.APP_URL || DEFAULT_FRONT_END_URL;
+	const email = process.env.TEST_EMAIL || DEFAULT_EMAIL;
+	const password = process.env.TEST_PASSWORD || DEFAULT_PASSWORD;
+	const firstName = process.env.TEST_FIRST_NAME || DEFAULT_FIRST_NAME;
+	const lastName = process.env.TEST_LAST_NAME || DEFAULT_LAST_NAME;
 
 	let res = await fetch(`${serverUrl}/auth/sign-up`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ firstName, lastName, email, password }),
 	});
+	console.log('Sign-up response', res.status);
 
 	if (!res.ok) {
 		res = await fetch(`${serverUrl}/auth/log-in`, {
@@ -37,28 +45,25 @@ export async function login(page: Page): Promise<void> {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ email, password }),
 		});
+		console.log('Login response', res.status);
 	}
 
-	if (!res.ok) {
-		throw new Error(`Failed to authenticate user: ${res.status}`);
+	await page.goto(`${frontEndUrl}/auth/login`);
+	await page.fill('#email', email);
+	await page.fill('#password', password);
+	await Promise.all([
+		page.waitForURL((url) => !url.pathname.startsWith('/auth')),
+		page.click('button[type="submit"]'),
+	]);
+	await page.waitForLoadState('networkidle');
+	console.log('Login completed at', page.url());
+
+	if (page.url().includes('/auth')) {
+		console.log('Login did not navigate away; page HTML:', await page.content());
 	}
 
-	const setCookies = (res.headers as any).getSetCookie?.() || [];
-	const sidCookie = setCookies.find((c: string) => c.startsWith('sid='));
-	if (!sidCookie) {
-		throw new Error('No session cookie in response');
-	}
-	const value = sidCookie.split(';')[0].split('=')[1];
-	const cookie = {
-		name: 'sid',
-		value,
-		domain,
-		path: '/',
-		httpOnly: true,
-		secure: false,
-	};
+	const cookies = await page.context().cookies();
 	await fs.mkdir(path.dirname(cookiePath), { recursive: true });
-	await fs.writeFile(cookiePath, JSON.stringify([cookie], null, 2));
-	await page.context().addCookies([cookie]);
-	console.log('Authenticated and saved cookies');
+	await fs.writeFile(cookiePath, JSON.stringify(cookies, null, 2));
+	console.log('Authenticated via UI and saved cookies');
 }

--- a/packages/MemoryFlashCore/src/redux/env.ts
+++ b/packages/MemoryFlashCore/src/redux/env.ts
@@ -6,6 +6,6 @@ const getEnv = (viteVariable: string, nodeVariable: string) => {
 	}
 };
 
-export const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'API_BASE_URL');
+export const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'API_BASE_URL') || 'http://localhost:3333';
 
 export const IS_PRODUCTION = getEnv('MODE', 'NODE_ENV') === 'production';


### PR DESCRIPTION
## Summary
- create `.github/scripts/constants.ts` for default values
- update login script to use shared defaults and authenticate via UI
- confirm login navigates away from `/auth`
- point `DEFAULT_FRONT_END_URL` to the preview port
- add debug logging and default API url for screenshots

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_6854619c763c8328a098ac2132a02063