### PR TITLE
Add bars to notation settings

### DIFF
--- a/apps/react/src/components/notation/BarsSetting.tsx
+++ b/apps/react/src/components/notation/BarsSetting.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { NumberInput } from '../inputs';
+import { SettingsSection } from './SettingsSection';
+
+interface BarsSettingProps {
+	bars: number;
+	setBars: (n: number) => void;
+}
+
+export const BarsSetting: React.FC<BarsSettingProps> = ({ bars, setBars }) => (
+	<SettingsSection title="Bars">
+		<label className="flex items-center gap-2">
+			Count
+			<NumberInput
+				className="w-16"
+				min={1}
+				value={bars}
+				onChange={(e) => setBars(parseInt(e.target.value, 10) || 1)}
+			/>
+		</label>
+	</SettingsSection>
+);

--- a/apps/react/src/components/notation/NotationSettings.tsx
+++ b/apps/react/src/components/notation/NotationSettings.tsx
@@ -5,6 +5,7 @@ import { NoteSettings } from './NoteSettings';
 import { SettingsSection } from './SettingsSection';
 import { RangeSettings } from './RangeSettings';
 import { CardTypeOptions } from './CardTypeOptions';
+import { BarsSetting } from './BarsSetting';
 
 interface NotationSettingsProps {
 	onChange: (settings: NotationSettingsState) => void;
@@ -29,6 +30,7 @@ export const NotationSettings: React.FC<NotationSettingsProps> = ({ onChange }) 
 				onChange={update}
 			/>
 			<RangeSettings lowest={state.lowest} highest={state.highest} onChange={update} />
+			<BarsSetting bars={state.bars} setBars={(n) => update({ bars: n })} />
 			<SettingsSection title="Keys">
 				<KeySelector
 					selected={state.selected}

--- a/apps/react/src/components/notation/defaultSettings.ts
+++ b/apps/react/src/components/notation/defaultSettings.ts
@@ -7,6 +7,7 @@ export interface NotationSettingsState {
 	bassDur: NoteDuration;
 	lowest: string;
 	highest: string;
+	bars: number;
 	selected: boolean[];
 	cardType: 'Sheet Music' | 'Text Prompt';
 	textPrompt: string;
@@ -18,6 +19,7 @@ export const defaultSettings: NotationSettingsState = {
 	bassDur: 'q',
 	lowest: 'C3',
 	highest: 'C5',
+	bars: 1,
 	selected: majorKeys.map(() => true),
 	cardType: 'Sheet Music',
 	textPrompt: '',

--- a/apps/react/src/components/notation/index.ts
+++ b/apps/react/src/components/notation/index.ts
@@ -5,3 +5,4 @@ export * from './CardTypeOptions';
 export * from './SettingsSection';
 export * from './NotationPreviewList';
 export * from './defaultSettings';
+export * from './BarsSetting';

--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -21,7 +21,7 @@ export const NotationInputScreen = () => {
 	const dispatch = useAppDispatch();
 	const { deckId } = useDeckIdPath();
 
-	const recorderRef = useRef(new MusicRecorder('q', 'C4', 'q', bars));
+	const recorderRef = useRef(new MusicRecorder('q', 'C4', 'q', defaultSettings.bars));
 	const midiNotes = useAppSelector(
 		(state) => state.midi.notes.map((n) => n.number),
 		shallowEqual,
@@ -36,9 +36,9 @@ export const NotationInputScreen = () => {
 	}, [settings.bassDur]);
 
 	useEffect(() => {
-		recorderRef.current.setBars(bars);
+		recorderRef.current.setBars(settings.bars);
 		recorderRef.current.reset();
-	}, [bars]);
+	}, [settings.bars]);
 
 	useEffect(() => {
 		recorderRef.current.addMidiNotes(midiNotes);


### PR DESCRIPTION
## Summary
- include bar count in `NotationSettings`
- reset recorder when bar count changes
- wrap `BarsSetting` in `SettingsSection`

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68585bbb23288328beeb7145f273beb7