### PR TITLE
Handle empty deck on StudyScreen

### DIFF
--- a/apps/react/src/screens/StudyScreen/StudyScreen.tsx
+++ b/apps/react/src/screens/StudyScreen/StudyScreen.tsx
@@ -5,7 +5,7 @@ import { CircleHover } from '../../components/CircleHover';
 import { FlashCard } from '../../components/FlashCard';
 import { Layout } from '../../components/Layout';
 import { MidiInputsDropdown } from '../../components/MidiInputsDropdown';
-import { Spinner } from '../../components/Spinner';
+import { StudyScreenEmptyState } from './StudyScreenEmptyState';
 import { AnswerValidator } from '../../components/answer-validators/AnswerValidator';
 import { Keyboard } from '../../components/keyboard/KeyBoard';
 import { getDeck } from 'MemoryFlashCore/src/redux/actions/get-deck-action';
@@ -149,6 +149,7 @@ export const StudyScreen = () => {
 			}
 			subtitle={course && deck && `${course?.name} · ${deck?.name}`}
 		>
+			<StudyScreenEmptyState />
 			<div className="flex flex-1" ref={cardContainerRef}>
 				<div
 					className="flex items-center"
@@ -157,7 +158,6 @@ export const StudyScreen = () => {
 						transition: 'transform 0.5s ease',
 					}}
 				>
-					<Spinner show={cards.length === 0} />
 					{cards.map((card, i) => (
 						<FlashCard
 							ref={(el) => (cardRefs.current[i] = el!)}

--- a/apps/react/src/screens/StudyScreen/StudyScreenEmptyState.tsx
+++ b/apps/react/src/screens/StudyScreen/StudyScreenEmptyState.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+import { Button } from '../../components/Button';
+import { BasicErrorCard } from '../../components/ErrorCard';
+import { Spinner } from '../../components/Spinner';
+import { useDeckIdPath } from '../useDeckIdPath';
+import { useNetworkState } from 'MemoryFlashCore/src/redux/selectors/useNetworkState';
+import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
+import { sessionCardsSelector } from 'MemoryFlashCore/src/redux/selectors/scheduledCardsSelector';
+
+export const StudyScreenEmptyState: React.FC = () => {
+	const { deckId, deck } = useDeckIdPath();
+	const { cards } = useAppSelector(sessionCardsSelector);
+	const { isLoading, error } = useNetworkState('getDeck' + deckId);
+	const course = useAppSelector((state) =>
+		deck?.courseId ? state.courses.entities[deck.courseId] : undefined,
+	);
+	const user = useAppSelector((state) => state.auth.user);
+	const isOwner = !!(course && user && course.userId === user._id);
+
+	if (cards.length > 0) return null;
+	return (
+		<>
+			<Spinner show={isLoading} />
+			<BasicErrorCard error={error} />
+			{!isLoading &&
+				(isOwner ? (
+					<Link to={`/study/${deckId}/notation`} className="w-full flex justify-center">
+						<Button className="w-48">Add Cards</Button>
+					</Link>
+				) : (
+					<div className="text-center text-gray-500 w-full">This deck has no cards.</div>
+				))}
+		</>
+	);
+};


### PR DESCRIPTION
## Summary
- load deck info inside `StudyScreenEmptyState` instead of passing props
- simplify `StudyScreen` now that the empty state component reads from redux

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68586182a06c8328821edc5217696298