### PR TITLE
Fix screenshot test root selector

### DIFF
--- a/apps/react/tests/helpers.ts
+++ b/apps/react/tests/helpers.ts
@@ -15,12 +15,7 @@ export const test = base.extend<{ page: Page }>({
 	},
 });
 
-export async function captureScreenshot(
-	page: Page,
-	url: string,
-	name: string,
-	selector = '#output',
-) {
+export async function captureScreenshot(page: Page, url: string, name: string, selector = '#root') {
 	await page.goto(url);
 	const output = page.locator(selector);
 	await output.waitFor();

--- a/apps/react/tests/music-recorder-bass-whole-eighth-rest.spec.ts
+++ b/apps/react/tests/music-recorder-bass-whole-eighth-rest.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicRecorder bass whole with treble eighth rest then notes', async ({ page }) => {
 	await page.goto('/tests/music-recorder-bass-whole-eighth-rest-test.html');
-	const output = page.locator('#output');
+	const output = page.locator('#root');
 
 	const treble = [[60], [], [62], [], [64], [], [65], []];
 

--- a/apps/react/tests/music-recorder-bass-whole-quarter.spec.ts
+++ b/apps/react/tests/music-recorder-bass-whole-quarter.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicRecorder bass whole with treble quarters', async ({ page }) => {
 	await page.goto('/tests/music-recorder-bass-whole-quarter-test.html');
-	const output = page.locator('#output');
+	const output = page.locator('#root');
 
 	const treble = [[60], [], [62], [], [64], [], [65], []];
 

--- a/apps/react/tests/music-recorder-chord.spec.ts
+++ b/apps/react/tests/music-recorder-chord.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicRecorder chord screenshot', async ({ page }) => {
 	await page.goto('/tests/music-recorder-chord-test.html');
-	const output = page.locator('#output');
+	const output = page.locator('#root');
 	const events = [[60], [60, 64], [60, 64, 67], [], [65]];
 
 	for (let i = 0; i < events.length; i++) {

--- a/apps/react/tests/music-recorder-cross-clef.spec.ts
+++ b/apps/react/tests/music-recorder-cross-clef.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicRecorder cross-clef rests', async ({ page }) => {
 	await page.goto('/tests/music-recorder-cross-clef-test.html');
-	const output = page.locator('#output');
+	const output = page.locator('#root');
 	const events = [[60], [], [48], [], [60], [], [48], []];
 
 	for (let i = 0; i < events.length; i++) {

--- a/apps/react/tests/music-recorder-two-measures.spec.ts
+++ b/apps/react/tests/music-recorder-two-measures.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, screenshotOpts } from './helpers';
 
 test('MusicRecorder two measures screenshot', async ({ page }) => {
 	await page.goto('/tests/music-recorder-two-measures-test.html');
-	const output = page.locator('#output');
+	const output = page.locator('#root');
 	const events = [60, 62, 64, 65, 67, 69, 71, 72, 74];
 	for (const m of events) {
 		await page.evaluate((n) => {


### PR DESCRIPTION
## Summary
- fix helper to look for `#root` when capturing screenshots
- align recorder screenshot tests with the new selector

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_68586962ec1c832885c7e1864f2ff1fe