### PR TITLE
Fix Vexflow empty measure crash

### DIFF
--- a/apps/react/src/components/MusicNotation.tsx
+++ b/apps/react/src/components/MusicNotation.tsx
@@ -125,7 +125,9 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 				});
 
 				// Space and draw the notes
-				VF.Formatter.FormatAndDraw(ctx, stave, notes);
+				if (notes.length) {
+					VF.Formatter.FormatAndDraw(ctx, stave, notes);
+				}
 
 				// --- CHORD TEXT (fixed): wrap in a Voice, format, then draw ---
 				if (!hideChords && staffType === StaffEnum.Treble) {
@@ -163,15 +165,17 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 							.setStave(stave);
 					});
 
-					const textVoice = new VF.Voice({
-						num_beats: BEATS_PER_MEASURE,
-						beat_value: 4,
-					}).addTickables(textNotes);
+					if (textNotes.length) {
+						const textVoice = new VF.Voice({
+							num_beats: BEATS_PER_MEASURE,
+							beat_value: 4,
+						}).addTickables(textNotes);
 
-					const textFormatter = new VF.Formatter();
-					textFormatter.joinVoices([textVoice]);
-					textFormatter.formatToStave([textVoice], stave);
-					textVoice.draw(ctx, stave);
+						const textFormatter = new VF.Formatter();
+						textFormatter.joinVoices([textVoice]);
+						textFormatter.formatToStave([textVoice], stave);
+						textVoice.draw(ctx, stave);
+					}
 				}
 
 				// Draw barline at end of this measure

--- a/apps/react/tests/music-recorder-cross-clef-two-measures-test.html
+++ b/apps/react/tests/music-recorder-cross-clef-two-measures-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicRecorder Cross Clef Two Measures Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/music-recorder-cross-clef-two-measures-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/music-recorder-cross-clef-two-measures-test.tsx
+++ b/apps/react/tests/music-recorder-cross-clef-two-measures-test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MusicRecorder } from 'MemoryFlashCore/src/lib/MusicRecorder';
+import { renderApp } from './renderApp';
+
+const recorder = new MusicRecorder('q', 'C4', 'q', 2);
+(window as any).recorder = recorder;
+
+const App: React.FC = () => {
+	const [data, setData] = React.useState(recorder.buildQuestion('C'));
+
+	React.useEffect(() => {
+		(window as any).update = () => setData(recorder.buildQuestion('C'));
+	}, []);
+
+	return <MusicNotation data={data} />;
+};
+
+renderApp(<App />);

--- a/apps/react/tests/music-recorder-cross-clef-two-measures.spec.ts
+++ b/apps/react/tests/music-recorder-cross-clef-two-measures.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from './helpers';
+
+const events = [[60], [], [48], [], [60], [], [48], [], [60], []];
+
+test('cross clef two measures no errors', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(msg.text());
+	});
+
+	await page.goto('/tests/music-recorder-cross-clef-two-measures-test.html');
+	const output = page.locator('#root');
+
+	for (const notes of events) {
+		await page.evaluate((n) => {
+			(window as any).recorder.addMidiNotes(n);
+			(window as any).update();
+		}, notes);
+	}
+	await output.waitFor();
+	await expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- avoid calling FormatAndDraw on empty arrays in `MusicNotation`
- guard chord formatting when there are no chord notes
- add regression test for entering notes across two measures with two clefs

## Testing
- `yarn test:codex` *(fails: Timeout of 10000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_685e313d6bbc8328b27f50ec3f3617e3