### PR TITLE
Disable new card shuffle

### DIFF
--- a/packages/MemoryFlashCore/src/redux/actions/schedule-cards-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/schedule-cards-action.ts
@@ -26,7 +26,7 @@ export const schedule =
 		if (getState().scheduler.nextCards.length > 12) return;
 
 		let cards = currDeckWithCorrectAttemptsSortedArray(getState());
-		let cardsWithNoAttempts = shuffleArray(cards.filter((card) => card.attempts.length === 0));
+		let cardsWithNoAttempts = cards.filter((card) => card.attempts.length === 0);
 		let cardsWithAttempts = cards.filter((card) => card.attempts.length > 0);
 		let medianTimeTaken = calculateMedian(
 			cardsWithAttempts.map((c) => c.attempts[0]?.timeTaken),


### PR DESCRIPTION
## Summary
- keep cards with no attempts in their existing order instead of shuffling

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_685e3f20e6488328b3052f2b90bdb5ff