### PR TITLE
Add cross clef chord screenshot test

### DIFF
--- a/apps/react/tests/notation-input-cross-clef-chord.spec.ts
+++ b/apps/react/tests/notation-input-cross-clef-chord.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, screenshotOpts } from './helpers'; // Verify chord across clefs
+test('cross clef chord input', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(msg.text());
+	});
+
+	await page.goto('/tests/notation-input-screen-test.html');
+	const output = page.locator('#root');
+	await output.waitFor();
+
+	const press = async (midi: number) =>
+		page.evaluate(
+			(n) => (window as any).store.dispatch({ type: 'midi/addNote', payload: n }),
+			midi,
+		);
+	const release = async (midi: number) =>
+		page.evaluate(
+			(n) => (window as any).store.dispatch({ type: 'midi/removeNote', payload: n }),
+			midi,
+		);
+	for (const [i, n] of [36, 48, 60, 72].entries()) {
+		await press(n);
+		await output.waitFor();
+		await expect(output).toHaveScreenshot(
+			`notation-input-cross-clef-chord-${i + 1}.png`,
+			screenshotOpts,
+		);
+	}
+	for (const n of [36, 48, 60, 72]) await release(n);
+
+	await page.waitForTimeout(200);
+	expect(errors).toEqual([]);
+});

--- a/apps/react/tests/notation-input-cross-clef-chord.spec.ts
+++ b/apps/react/tests/notation-input-cross-clef-chord.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, screenshotOpts } from './helpers'; // Verify chord across clefs
+import { test, expect, screenshotOpts } from './helpers';
+
 test('cross clef chord input', async ({ page }) => {
 	const errors: string[] = [];
 	page.on('pageerror', (err) => errors.push(err.message));
@@ -20,15 +21,25 @@ test('cross clef chord input', async ({ page }) => {
 			(n) => (window as any).store.dispatch({ type: 'midi/removeNote', payload: n }),
 			midi,
 		);
+
+	const scrollToNotation = () =>
+		page.evaluate(() => {
+			window.scrollTo(0, 0);
+			document.querySelector('.overflow-scroll')?.scrollTo(0, 300);
+		});
+
 	for (const [i, n] of [36, 48, 60, 72].entries()) {
 		await press(n);
+		await scrollToNotation();
 		await output.waitFor();
 		await expect(output).toHaveScreenshot(
 			`notation-input-cross-clef-chord-${i + 1}.png`,
 			screenshotOpts,
 		);
 	}
-	for (const n of [36, 48, 60, 72]) await release(n);
+	for (const n of [36, 48, 60, 72]) {
+		await release(n);
+	}
 
 	await page.waitForTimeout(200);
 	expect(errors).toEqual([]);


### PR DESCRIPTION
## Summary
- capture screenshots while building a cross-clef chord on `NotationInputScreen`

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_685e4534bb348328b6bea772c5522b74