### PR TITLE
Handle accidentals based on key signature

### DIFF
--- a/apps/react/src/components/MusicNotation.tsx
+++ b/apps/react/src/components/MusicNotation.tsx
@@ -9,6 +9,7 @@ import {
 	Accidental,
 	Barline,
 } from 'vexflow';
+import { majorKey, minorKey } from '@tonaljs/key';
 import { MultiSheetQuestion, Voice } from 'MemoryFlashCore/src/types/MultiSheetCard';
 import { calcBars } from 'MemoryFlashCore/src/lib/calcBars';
 import { durationBeats } from 'MemoryFlashCore/src/lib/measure';
@@ -87,6 +88,12 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 		const measuresByVoice = voiceIndexed.map(splitMeasures);
 		const chordMeasures = measuresByVoice[0];
 
+		const diatonic = new Set(
+			data.key.endsWith('m')
+				? minorKey(data.key.slice(0, -1)).natural.scale
+				: majorKey(data.key).scale,
+		);
+
 		for (let bar = 0; bar < bars; bar++) {
 			const x = bar * BAR_WIDTH;
 			const isFirstBar = bar === 0;
@@ -119,8 +126,11 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 
 					if (!isRest) {
 						sn.notes.forEach((n, i) => {
-							const accidental = n.name.slice(1);
-							if (accidental) note.addModifier(new VF.Accidental(accidental), i);
+							let accidental = n.name.slice(1);
+							if (!diatonic.has(n.name)) {
+								if (!accidental) accidental = 'n';
+								note.addModifier(new VF.Accidental(accidental), i);
+							}
 						});
 					}
 

--- a/apps/react/tests/music-notation-accidentals-test.html
+++ b/apps/react/tests/music-notation-accidentals-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicNotation Accidentals Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/music-notation-accidentals-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/music-notation-accidentals-test.tsx
+++ b/apps/react/tests/music-notation-accidentals-test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+import { renderApp } from './renderApp';
+
+const data: MultiSheetQuestion = {
+	key: 'Eb',
+	voices: [
+		{
+			staff: StaffEnum.Treble,
+			stack: [
+				{ notes: [{ name: 'Eb', octave: 4 }], duration: 'q' },
+				{ notes: [{ name: 'E', octave: 4 }], duration: 'q' },
+				{ notes: [{ name: 'Db', octave: 4 }], duration: 'q' },
+			],
+		},
+	],
+};
+
+renderApp(<MusicNotation data={data} highlightClassName="highlight" />);

--- a/apps/react/tests/music-notation-accidentals.spec.ts
+++ b/apps/react/tests/music-notation-accidentals.spec.ts
@@ -1,0 +1,9 @@
+import { test, captureScreenshot } from './helpers';
+
+test('MusicNotation accidentals screenshot', async ({ page }) => {
+	await captureScreenshot(
+		page,
+		'/tests/music-notation-accidentals-test.html',
+		'music-notation-accidentals.png',
+	);
+});


### PR DESCRIPTION
## Summary
- only display accidentals when the note is outside the key signature
- add screenshot spec for accidentals in Eb major

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_6864cf6915948328937fd9568a24117e