### PR TITLE
Fix edit button ownership check

### DIFF
--- a/apps/react/src/App.tsx
+++ b/apps/react/src/App.tsx
@@ -41,6 +41,10 @@ export default function App() {
 						element={<AuthenticatedRoute screen={<NotationInputScreen />} />}
 					/>
 					<Route
+						path="/study/:deckId/edit/:cardId"
+						element={<AuthenticatedRoute screen={<NotationInputScreen />} />}
+					/>
+					<Route
 						path="/course/:courseId"
 						element={<AuthenticatedRoute screen={<DecksScreen />} />}
 					/>

--- a/apps/react/src/components/FlashCard.tsx
+++ b/apps/react/src/components/FlashCard.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
 import { CardTypeEnum, IntervalCard } from 'MemoryFlashCore/src/types/Cards';
 import { MultiSheetCardQuestion } from './FlashCards/MultiSheetCardQuestion';
 import { Pill } from './Pill';
+import { FlashCardEditButton } from './FlashCardEditButton';
 
 type Placement = 'cur' | 'scheduled' | 'answered';
 
@@ -13,6 +14,7 @@ interface FlashCardProps {
 	placement: Placement;
 	className?: string;
 	opacity?: number;
+	showEdit?: boolean;
 }
 
 export interface QuestionRender {
@@ -35,7 +37,7 @@ let QuestionComponentMap: { [cardType: string]: React.FC<QuestionRender> } = {
 };
 
 export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
-	({ card, className, opacity, placement }, ref) => {
+	({ card, className, opacity, placement, showEdit }, ref) => {
 		const QuestionComponent = QuestionComponentMap[card.type];
 		if (!QuestionComponent) {
 			console.error('No question component found for card type', card.type);
@@ -45,12 +47,13 @@ export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
 		return (
 			<div
 				ref={ref}
-				className={`card-container flex flex-col justify-between items-center min-w-[15rem] h-60  m-4 ${className}`}
+				className={`relative card-container flex flex-col justify-between items-center min-w-[15rem] h-60  m-4 ${className}`}
 				style={{
 					opacity,
 					transition: 'opacity 0.5s ease',
 				}}
 			>
+				<FlashCardEditButton card={card} show={showEdit} />
 				<div className="text-4xl font-medium flex flex-1 justify-center items-center">
 					<QuestionComponent card={card} placement={placement} />
 				</div>

--- a/apps/react/src/components/FlashCardEditButton.tsx
+++ b/apps/react/src/components/FlashCardEditButton.tsx
@@ -1,0 +1,23 @@
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
+import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
+import { CardWithAttempts } from 'MemoryFlashCore/src/redux/selectors/currDeckCardsWithAttempts';
+import { CircleHover } from './CircleHover';
+
+interface FlashCardEditButtonProps {
+	card: CardWithAttempts;
+	show?: boolean;
+}
+
+export const FlashCardEditButton: React.FC<FlashCardEditButtonProps> = ({ card, show }) => {
+	const user = useAppSelector((state) => state.auth.user);
+
+	if (!show || !user || (card as any).userId !== user._id) return null;
+
+	return (
+		<div className="absolute right-1 top-1">
+			<CircleHover link={`/study/${card.deckId}/edit/${card._id}`}>
+				<PencilSquareIcon className="w-4 h-4" />
+			</CircleHover>
+		</div>
+	);
+};

--- a/apps/react/src/screens/AllDeckCardsScreen.tsx
+++ b/apps/react/src/screens/AllDeckCardsScreen.tsx
@@ -34,14 +34,13 @@ export const AllDeckCardsScreen: React.FunctionComponent<AllDeckCardsScreenProps
 			<div className="flex flex-col items-center">
 				<div className="mb-4">{deck.length} cards</div>
 				{deck.map((card, i) => (
-					<div className="inline-block">
-						<FlashCard
-							placement={'cur'}
-							key={card._id + i}
-							card={card}
-							className={`card-shadow-2`}
-						/>
-					</div>
+					<FlashCard
+						key={card._id + i}
+						placement={'cur'}
+						card={card}
+						className={`card-shadow-2`}
+						showEdit
+					/>
 				))}
 			</div>
 		</Layout>

--- a/apps/react/src/screens/StudyScreen/StudyScreen.tsx
+++ b/apps/react/src/screens/StudyScreen/StudyScreen.tsx
@@ -160,12 +160,13 @@ export const StudyScreen = () => {
 				>
 					{cards.map((card, i) => (
 						<FlashCard
+							key={card._id + i}
 							ref={(el) => (cardRefs.current[i] = el!)}
 							placement={i === index ? 'cur' : i < index ? 'answered' : 'scheduled'}
-							key={card._id + i}
 							card={card}
 							className={`card-shadow-2 ${cardOpactity(i)}`}
 							opacity={cardOpactity(i)}
+							showEdit={user && (card as any).userId === user._id && i === index}
 						/>
 					))}
 				</div>

--- a/apps/react/tests/notation-input-edit-test.html
+++ b/apps/react/tests/notation-input-edit-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>NotationInputScreen Edit Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/notation-input-edit-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/notation-input-edit-test.tsx
+++ b/apps/react/tests/notation-input-edit-test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { NotationInputScreen } from '../src/screens/NotationInputScreen';
+import '../src/index.css';
+import { renderApp } from './renderApp';
+
+renderApp(
+	<MemoryRouter initialEntries={['/study/deck1/edit/card1']}>
+		<Routes>
+			<Route path="/study/:deckId/edit/:cardId" element={<NotationInputScreen />} />
+		</Routes>
+	</MemoryRouter>,
+);

--- a/apps/react/tests/notation-input-edit.spec.ts
+++ b/apps/react/tests/notation-input-edit.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from './helpers';
+
+// verify edit mode shows Update Card button
+
+test('NotationInputScreen edit flow', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(msg.text());
+	});
+
+	await page.goto('/tests/notation-input-edit-test.html');
+	await page.locator('#root').waitFor();
+
+	const cardPayload = {
+		_id: 'card1',
+		deckId: 'deck1',
+		type: 'MultiSheet',
+		question: { key: 'C', voices: [] },
+		answer: { type: 'ExactMulti' },
+	};
+
+	await page.evaluate((c) => {
+		(window as any).store.dispatch({ type: 'cards/upsert', payload: [c] });
+	}, cardPayload);
+
+	await expect(page.getByRole('button', { name: 'Update Card' })).toHaveText('Update Card');
+	expect(errors).toEqual([]);
+});

--- a/apps/server/src/routes/cardsRouter.ts
+++ b/apps/server/src/routes/cardsRouter.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { isAuthenticated } from '../middleware';
+import { updateCard } from '../services/cardService';
+import { User } from 'MemoryFlashCore/src/types/User';
+
+const router = Router();
+
+router.patch('/:id', isAuthenticated, async (req, res, next) => {
+	try {
+		const card = await updateCard(
+			req.params.id,
+			req.body.question,
+			(req.user as User)._id.toString(),
+		);
+		return res.json({ card });
+	} catch (error) {
+		next(error);
+	}
+});
+
+export { router as cardsRouter };

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -5,6 +5,7 @@ import { authRouter } from './authRoute';
 import { decksRouter } from './decksRouter';
 import { coursesRouter } from './coursesRouter';
 import { attemptsRouter } from './attemptsRoute';
+import { cardsRouter } from './cardsRouter';
 
 const router = Router();
 
@@ -17,6 +18,7 @@ router.use('/auth', authRouter);
 router.use('/decks', decksRouter);
 router.use('/courses', coursesRouter);
 router.use('/attempts', attemptsRouter);
+router.use('/cards', cardsRouter);
 router.use(notFound);
 
 export { router as api };

--- a/apps/server/src/services/cardService.ts
+++ b/apps/server/src/services/cardService.ts
@@ -1,0 +1,17 @@
+import Course from '../models/Course';
+import { Card } from '../models/Card';
+import { Deck } from '../models/Deck';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+
+export async function updateCard(cardId: string, question: MultiSheetQuestion, userId: string) {
+	const card = await Card.findById(cardId);
+	if (!card) return null;
+	const deck = await Deck.findById(card.deckId);
+	if (!deck) return null;
+	const course = await Course.findById(deck.courseId);
+	if (!course || course.userId?.toString() !== userId) return null;
+
+	card.question = question;
+	await card.save();
+	return card;
+}

--- a/packages/MemoryFlashCore/src/redux/actions/update-card-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/update-card-action.ts
@@ -1,0 +1,34 @@
+import { cardsActions } from '../slices/cardsSlice';
+import { AppThunk } from '../store';
+import { networkCallWithReduxState } from '../util/networkStateHelper';
+import { MultiSheetQuestion } from '../../types/MultiSheetCard';
+import { CardTypeEnum } from '../../types/Cards';
+
+function prepareQuestion(
+	question: MultiSheetQuestion,
+	cardType: string,
+	textPrompt?: string,
+): MultiSheetQuestion {
+	if (cardType === 'Text Prompt') {
+		return {
+			...question,
+			presentationModes: [{ id: 'Text Prompt', text: textPrompt ?? '' }],
+		} as any;
+	}
+	return question;
+}
+
+export const updateCard =
+	(
+		cardId: string,
+		question: MultiSheetQuestion,
+		cardType: CardTypeEnum | string,
+		textPrompt?: string,
+	): AppThunk =>
+	async (dispatch, _, { api }) => {
+		await networkCallWithReduxState(dispatch, 'updateCard', async () => {
+			const q = prepareQuestion(question, cardType, textPrompt);
+			const res = await api.patch('/cards/' + cardId, { question: q });
+			dispatch(cardsActions.upsert([res.data.card]));
+		});
+	};


### PR DESCRIPTION
## Summary
- check user id directly on FlashCardEditButton
- show edit option on StudyScreen using card's userId
- add edit route test using MemoryRouter

## Testing
- `yarn test:codex`
- `yarn workspace MemoryFlashReact test:screenshots`

------
https://chatgpt.com/codex/tasks/task_e_685e43f7b65c8328818f4af7fdbb2b3e