### PR TITLE
Add reset ability to notation screen

### DIFF
--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -85,6 +85,10 @@ export const NotationInputScreen = () => {
 		}
 	};
 
+	const handleReset = () => {
+		recorderRef.current.reset();
+	};
+
 	const error = updateError || addError;
 
 	return (
@@ -97,7 +101,8 @@ export const NotationInputScreen = () => {
 				previewTextCard={settings.preview}
 			/>
 			<BasicErrorCard error={error} />
-			<div className="pt-4 flex justify-center">
+			<div className="pt-4 flex justify-center gap-3">
+				<Button onClick={handleReset}>Reset</Button>
 				<Button
 					onClick={cardId ? handleUpdate : handleAdd}
 					loading={cardId ? isUpdating : isAdding}

--- a/apps/react/tests/notation-input-edit.spec.ts
+++ b/apps/react/tests/notation-input-edit.spec.ts
@@ -25,5 +25,6 @@ test('NotationInputScreen edit flow', async ({ page }) => {
 	}, cardPayload);
 
 	await expect(page.getByRole('button', { name: 'Update Card' })).toHaveText('Update Card');
+	await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible();
 	expect(errors).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- enable clearing the music recorder from NotationInputScreen
- show the Reset button next to Update/Add
- test that Reset is visible in edit mode

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_686813b9ce548328beb5cda885de31ab