### PR TITLE
Refactor Playwright helpers

### DIFF
--- a/apps/react/tests/helpers.ts
+++ b/apps/react/tests/helpers.ts
@@ -7,11 +7,20 @@ const blockFonts = process.env.BLOCK_REMOTE_FONTS === 'true';
 
 export const test = base.extend<{ page: Page }>({
 	page: async ({ page }, use) => {
+		const errors: string[] = [];
+		page.on('pageerror', (err) => errors.push(err.message));
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') errors.push(msg.text());
+		});
+
 		if (blockFonts) {
 			await page.route('https://fonts.googleapis.com/**', (route) => route.abort());
 			await page.route('https://fonts.gstatic.com/**', (route) => route.abort());
 		}
+
 		await use(page);
+
+		expect(errors).toEqual([]);
 	},
 });
 
@@ -20,6 +29,29 @@ export async function captureScreenshot(page: Page, url: string, name: string, s
 	const output = page.locator(selector);
 	await output.waitFor();
 	await expect(output).toHaveScreenshot(name, screenshotOpts);
+}
+
+export async function runRecorderEvents(
+	page: Page,
+	url: string,
+	events: number[][],
+	prefix: string,
+	afterStep?: (index: number) => Promise<void> | void,
+) {
+	await page.goto(url);
+	const output = page.locator('#root');
+
+	for (let i = 0; i < events.length; i++) {
+		await page.evaluate((n) => {
+			(window as any).recorder.addMidiNotes(n);
+			(window as any).update();
+		}, events[i]);
+		await output.waitFor();
+		await expect(output).toHaveScreenshot(`${prefix}-${i + 1}.png`, screenshotOpts);
+		if (afterStep) await afterStep(i);
+	}
+
+	return output;
 }
 
 export { expect };

--- a/apps/react/tests/music-recorder-bass-whole-eighth-rest.spec.ts
+++ b/apps/react/tests/music-recorder-bass-whole-eighth-rest.spec.ts
@@ -1,27 +1,18 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts, runRecorderEvents } from './helpers';
 
 test('MusicRecorder bass whole with treble eighth rest then notes', async ({ page }) => {
-	await page.goto('/tests/music-recorder-bass-whole-eighth-rest-test.html');
-	const output = page.locator('#root');
-
 	const treble = [[60], [], [62], [], [64], [], [65], []];
 
-	for (let i = 0; i < treble.length; i++) {
-		await page.evaluate((notes) => {
-			(window as any).recorder.addMidiNotes(notes);
-			(window as any).update();
-		}, treble[i]);
-		await output.waitFor();
-		await expect(output).toHaveScreenshot(
-			`music-recorder-bass-whole-eighth-rest-${i + 1}.png`,
-			screenshotOpts,
-		);
-		if (i === 1) {
-			await page.evaluate(() => {
-				(window as any).recorder.updateDuration('q', 'Treble');
-			});
-		}
-	}
+	const output = await runRecorderEvents(
+		page,
+		'/tests/music-recorder-bass-whole-eighth-rest-test.html',
+		treble,
+		'music-recorder-bass-whole-eighth-rest',
+		async (i) => {
+			if (i === 1)
+				await page.evaluate(() => (window as any).recorder.updateDuration('q', 'Treble'));
+		},
+	);
 
 	await page.evaluate(() => {
 		(window as any).recorder.currentBeat = 0;

--- a/apps/react/tests/music-recorder-bass-whole-quarter.spec.ts
+++ b/apps/react/tests/music-recorder-bass-whole-quarter.spec.ts
@@ -1,22 +1,14 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts, runRecorderEvents } from './helpers';
 
 test('MusicRecorder bass whole with treble quarters', async ({ page }) => {
-	await page.goto('/tests/music-recorder-bass-whole-quarter-test.html');
-	const output = page.locator('#root');
-
 	const treble = [[60], [], [62], [], [64], [], [65], []];
 
-	for (let i = 0; i < treble.length; i++) {
-		await page.evaluate((notes) => {
-			(window as any).recorder.addMidiNotes(notes);
-			(window as any).update();
-		}, treble[i]);
-		await output.waitFor();
-		await expect(output).toHaveScreenshot(
-			`music-recorder-bass-whole-quarter-${i + 1}.png`,
-			screenshotOpts,
-		);
-	}
+	const output = await runRecorderEvents(
+		page,
+		'/tests/music-recorder-bass-whole-quarter-test.html',
+		treble,
+		'music-recorder-bass-whole-quarter',
+	);
 
 	await page.evaluate(() => {
 		(window as any).recorder.currentBeat = 0;

--- a/apps/react/tests/music-recorder-chord.spec.ts
+++ b/apps/react/tests/music-recorder-chord.spec.ts
@@ -1,16 +1,12 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts, runRecorderEvents } from './helpers';
 
 test('MusicRecorder chord screenshot', async ({ page }) => {
-	await page.goto('/tests/music-recorder-chord-test.html');
-	const output = page.locator('#root');
 	const events = [[60], [60, 64], [60, 64, 67], [], [65]];
 
-	for (let i = 0; i < events.length; i++) {
-		await page.evaluate((notes) => {
-			(window as any).recorder.addMidiNotes(notes);
-			(window as any).update();
-		}, events[i]);
-		await output.waitFor();
-		await expect(output).toHaveScreenshot(`music-recorder-chord-${i + 1}.png`, screenshotOpts);
-	}
+	await runRecorderEvents(
+		page,
+		'/tests/music-recorder-chord-test.html',
+		events,
+		'music-recorder-chord',
+	);
 });

--- a/apps/react/tests/music-recorder-cross-clef-two-measures.spec.ts
+++ b/apps/react/tests/music-recorder-cross-clef-two-measures.spec.ts
@@ -1,28 +1,12 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts, runRecorderEvents } from './helpers';
 
 const events = [[60], [], [48], [], [60], [], [48], [], [60], []];
 
 test('cross clef two measures', async ({ page }) => {
-	const errors: string[] = [];
-	page.on('pageerror', (err) => errors.push(err.message));
-	page.on('console', (msg) => {
-		if (msg.type() === 'error') errors.push(msg.text());
-	});
-
-	await page.goto('/tests/music-recorder-cross-clef-two-measures-test.html');
-	const output = page.locator('#root');
-
-	for (let i = 0; i < events.length; i++) {
-		await page.evaluate((notes) => {
-			(window as any).recorder.addMidiNotes(notes);
-			(window as any).update();
-		}, events[i]);
-		await output.waitFor();
-		await expect(output).toHaveScreenshot(
-			`music-recorder-cross-clef-two-measures-${i + 1}.png`,
-			screenshotOpts,
-		);
-	}
-
-	await expect(errors).toEqual([]);
+	await runRecorderEvents(
+		page,
+		'/tests/music-recorder-cross-clef-two-measures-test.html',
+		events,
+		'music-recorder-cross-clef-two-measures',
+	);
 });

--- a/apps/react/tests/music-recorder-cross-clef.spec.ts
+++ b/apps/react/tests/music-recorder-cross-clef.spec.ts
@@ -1,19 +1,12 @@
-import { test, expect, screenshotOpts } from './helpers';
+import { test, expect, screenshotOpts, runRecorderEvents } from './helpers';
 
 test('MusicRecorder cross-clef rests', async ({ page }) => {
-	await page.goto('/tests/music-recorder-cross-clef-test.html');
-	const output = page.locator('#root');
 	const events = [[60], [], [48], [], [60], [], [48], []];
 
-	for (let i = 0; i < events.length; i++) {
-		await page.evaluate((notes) => {
-			(window as any).recorder.addMidiNotes(notes);
-			(window as any).update();
-		}, events[i]);
-		await output.waitFor();
-		await expect(output).toHaveScreenshot(
-			`music-recorder-cross-clef-${i + 1}.png`,
-			screenshotOpts,
-		);
-	}
+	await runRecorderEvents(
+		page,
+		'/tests/music-recorder-cross-clef-test.html',
+		events,
+		'music-recorder-cross-clef',
+	);
 });

--- a/apps/react/tests/notation-input-edit.spec.ts
+++ b/apps/react/tests/notation-input-edit.spec.ts
@@ -3,12 +3,6 @@ import { test, expect } from './helpers';
 // verify edit mode shows Update Card button
 
 test('NotationInputScreen edit flow', async ({ page }) => {
-	const errors: string[] = [];
-	page.on('pageerror', (err) => errors.push(err.message));
-	page.on('console', (msg) => {
-		if (msg.type() === 'error') errors.push(msg.text());
-	});
-
 	await page.goto('/tests/notation-input-edit-test.html');
 	await page.locator('#root').waitFor();
 
@@ -26,5 +20,4 @@ test('NotationInputScreen edit flow', async ({ page }) => {
 
 	await expect(page.getByRole('button', { name: 'Update Card' })).toHaveText('Update Card');
 	await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible();
-	expect(errors).toEqual([]);
 });

--- a/apps/react/tests/notation-input-overflow.spec.ts
+++ b/apps/react/tests/notation-input-overflow.spec.ts
@@ -1,12 +1,6 @@
 import { test, expect } from './helpers';
 
 test('NotationInputScreen handles overflow input', async ({ page }) => {
-	let errors: string[] = [];
-	page.on('pageerror', (err) => errors.push(err.message));
-	page.on('console', (msg) => {
-		if (msg.type() === 'error') errors.push(msg.text());
-	});
-
 	await page.goto('/tests/notation-input-screen-test.html');
 	await page.locator('#root').waitFor();
 
@@ -24,6 +18,4 @@ test('NotationInputScreen handles overflow input', async ({ page }) => {
 	}
 	await press(67);
 	await page.waitForTimeout(200);
-
-	expect(errors).toEqual([]);
 });

--- a/apps/react/tests/notation-input-screen.spec.ts
+++ b/apps/react/tests/notation-input-screen.spec.ts
@@ -3,17 +3,9 @@ import fs from 'fs';
 import path from 'path';
 
 test('NotationInputScreen renders with whole rest', async ({ page }) => {
-	const errors: string[] = [];
-	page.on('pageerror', (err) => errors.push(err.message));
-	page.on('console', (msg) => {
-		if (msg.type() === 'error') errors.push(msg.text());
-	});
-
 	await page.goto('/tests/notation-input-screen-test.html');
 	const output = page.locator('#root');
 	await output.waitFor();
 	await page.waitForTimeout(200);
-
-	expect(errors).toEqual([]);
 	await expect(output).toHaveScreenshot('notation-input-screen.png', screenshotOpts);
 });

--- a/apps/react/tests/notation-input-text-prompt.spec.ts
+++ b/apps/react/tests/notation-input-text-prompt.spec.ts
@@ -3,12 +3,6 @@ import { test, expect, screenshotOpts } from './helpers';
 // Test selecting Text Prompt card type on NotationInputScreen
 
 test('NotationInputScreen text prompt card type', async ({ page }) => {
-	const errors: string[] = [];
-	page.on('pageerror', (err) => errors.push(err.message));
-	page.on('console', (msg) => {
-		if (msg.type() === 'error') errors.push(msg.text());
-	});
-
 	await page.goto('/tests/notation-input-screen-test.html');
 	const output = page.locator('#root');
 	await output.waitFor();
@@ -22,6 +16,5 @@ test('NotationInputScreen text prompt card type', async ({ page }) => {
 		document.querySelector('.overflow-scroll')?.scrollTo(0, 300);
 	});
 
-	expect(errors).toEqual([]);
 	await expect(output).toHaveScreenshot('notation-input-text-prompt.png', screenshotOpts);
 });


### PR DESCRIPTION
## Summary
- centralize Playwright error handling
- add `runRecorderEvents` helper
- remove manual error listeners from specs
- refactor recorder specs to use shared helper

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_686869bc87bc8328a040e32e877201ea