### PR TITLE
Sync test recorder with MIDI store

### DIFF
--- a/apps/react/tests/renderApp.tsx
+++ b/apps/react/tests/renderApp.tsx
@@ -20,6 +20,15 @@ export function renderApp(
 	);
 	(window as any).store = store;
 
+	const recorder = (window as any).recorder;
+	if (recorder) {
+		store.subscribe(() => {
+			const notes = store.getState().midi.notes.map((n) => n.number);
+			recorder.addMidiNotes(notes);
+			(window as any).update?.();
+		});
+	}
+
 	ReactDOM.createRoot(document.getElementById(rootId)!).render(
 		<React.StrictMode>
 			<Provider store={store}>{element}</Provider>


### PR DESCRIPTION
## Summary
- ensure test render helper feeds MIDI note changes into MusicRecorder

## Testing
- `yarn workspace MemoryFlashReact test:screenshots tests/music-recorder-bass-whole-eighth-rest.spec.ts`
- `yarn workspace MemoryFlashReact test:screenshots tests/music-recorder-bass-whole-quarter.spec.ts`
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68b079ac258883288946cea670b3155e