### PR TITLE
Handle missing stack entries in answer validators

### DIFF
--- a/apps/react/src/components/answer-validators/ExactMultiAnswerValidator.tsx
+++ b/apps/react/src/components/answer-validators/ExactMultiAnswerValidator.tsx
@@ -24,7 +24,7 @@ export const ExactMultiAnswerValidator: React.FC<{ card: Card }> = ({ card: _car
 	const getNotesForPart = (index: number) => {
 		const partNotes = filterNullOrUndefined(
 			card.question.voices
-				.flatMap((voice) => voice.stack[index].notes)
+				.flatMap((voice) => voice.stack[index]?.notes ?? [])
 				.map((note) => Note.midi(note.name + note.octave)),
 		);
 		return partNotes;

--- a/apps/react/src/components/answer-validators/UnExactMultiAnswerValidator.tsx
+++ b/apps/react/src/components/answer-validators/UnExactMultiAnswerValidator.tsx
@@ -22,7 +22,7 @@ export const UnExactMultiAnswerValidator: React.FC<{ card: Card }> = ({ card: _c
 
 	const getChromaNotesForPart = (index: number): number[] => {
 		return card.question.voices
-			.flatMap((voice) => voice.stack[index].notes)
+			.flatMap((voice) => voice.stack[index]?.notes ?? [])
 			.map((note) => Note.chroma(note.name + note.octave));
 	};
 


### PR DESCRIPTION
## Summary
- avoid reading undefined voice stacks in ExactMultiAnswerValidator
- guard UnExactMultiAnswerValidator against missing voice stack parts

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68b141005294832894b87bfc6133b000