### PR TITLE
Allow unselecting keys in NotationInput

### DIFF
--- a/apps/react/src/components/KeySelector.tsx
+++ b/apps/react/src/components/KeySelector.tsx
@@ -4,13 +4,11 @@ import { Checkbox } from './inputs';
 
 interface KeySelectorProps {
 	selected: boolean[];
-	currentIndex: number;
 	onChange: (next: boolean[]) => void;
 }
 
-export const KeySelector: React.FC<KeySelectorProps> = ({ selected, currentIndex, onChange }) => {
+export const KeySelector: React.FC<KeySelectorProps> = ({ selected, onChange }) => {
 	const toggle = (i: number) => {
-		if (i === currentIndex) return;
 		const next = [...selected];
 		next[i] = !next[i];
 		onChange(next);
@@ -18,7 +16,7 @@ export const KeySelector: React.FC<KeySelectorProps> = ({ selected, currentIndex
 
 	const selectAll = () => onChange(selected.map(() => true));
 
-	const selectNone = () => onChange(selected.map((_, i) => i === currentIndex));
+	const selectNone = () => onChange(selected.map(() => false));
 
 	return (
 		<div className="flex flex-col gap-2 pb-4 items-start">
@@ -33,11 +31,7 @@ export const KeySelector: React.FC<KeySelectorProps> = ({ selected, currentIndex
 			<div className="grid grid-cols-4 gap-2">
 				{majorKeys.map((k, i) => (
 					<label key={k} className="flex items-center gap-1">
-						<Checkbox
-							checked={selected[i]}
-							onChange={() => toggle(i)}
-							disabled={i === currentIndex}
-						/>
+						<Checkbox checked={selected[i]} onChange={() => toggle(i)} />
 						<span>{k}</span>
 					</label>
 				))}

--- a/apps/react/src/components/notation/NotationSettings.tsx
+++ b/apps/react/src/components/notation/NotationSettings.tsx
@@ -43,7 +43,6 @@ export const NotationSettings: React.FC<NotationSettingsProps> = ({ onChange }) 
 			<SettingsSection title="Keys">
 				<KeySelector
 					selected={state.selected}
-					currentIndex={majorKeys.indexOf(state.keySig)}
 					onChange={(selected) => update({ selected })}
 				/>
 			</SettingsSection>


### PR DESCRIPTION
## Summary
- allow toggling off the current key in KeySelector
- update NotationSettings to use simplified KeySelector API

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_68b1526c11bc83289e2c32e3d57843e5