### PR TITLE
fix: avoid accidental for diatonic notes

### DIFF
--- a/apps/react/src/components/MusicNotation.tsx
+++ b/apps/react/src/components/MusicNotation.tsx
@@ -114,7 +114,9 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 				const notes = stack.map(({ sn, idx }) => {
 					const isRest = sn.rest || sn.notes.length === 0;
 					const restKey = staffType === StaffEnum.Bass ? 'd/3' : 'b/4';
-					const keys = isRest ? [restKey] : sn.notes.map((n) => `${n.name}/${n.octave}`);
+					const keys = isRest
+						? [restKey]
+						: sn.notes.map((n) => `${n.name[0].toLowerCase()}/${n.octave}`);
 					const dur = (isRest ? `${sn.duration}r` : sn.duration) as string;
 					const note = new VF.StaveNote({
 						keys,


### PR DESCRIPTION
## Summary
- prevent VexFlow from rendering accidentals for notes already in the key signature
- strip accidentals from note keys and only add modifiers when needed

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68b1544684748328a6ea9c097941f888