### PR TITLE
fix: avoid accidental for diatonic notes

### DIFF
--- a/apps/react/src/components/MusicNotation.tsx
+++ b/apps/react/src/components/MusicNotation.tsx
@@ -114,7 +114,9 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 				const notes = stack.map(({ sn, idx }) => {
 					const isRest = sn.rest || sn.notes.length === 0;
 					const restKey = staffType === StaffEnum.Bass ? 'd/3' : 'b/4';
-					const keys = isRest ? [restKey] : sn.notes.map((n) => `${n.name}/${n.octave}`);
+					const keys = isRest
+						? [restKey]
+						: sn.notes.map((n) => `${n.name[0].toLowerCase()}/${n.octave}`);
 					const dur = (isRest ? `${sn.duration}r` : sn.duration) as string;
 					const note = new VF.StaveNote({
 						keys,

--- a/apps/react/tests/music-notation-accidentals-e-major-test.html
+++ b/apps/react/tests/music-notation-accidentals-e-major-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>MusicNotation Accidentals E Major Test</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/tests/music-notation-accidentals-e-major-test.tsx"></script>
+	</body>
+</html>

--- a/apps/react/tests/music-notation-accidentals-e-major-test.tsx
+++ b/apps/react/tests/music-notation-accidentals-e-major-test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+import { renderApp } from './renderApp';
+
+const data: MultiSheetQuestion = {
+	key: 'E',
+	voices: [
+		{
+			staff: StaffEnum.Treble,
+			stack: [
+				{ notes: [{ name: 'F#', octave: 4 }], duration: 'q' },
+				{ notes: [{ name: 'G#', octave: 4 }], duration: 'q' },
+				{ notes: [{ name: 'F', octave: 4 }], duration: 'q' },
+				{ notes: [], duration: 'q', rest: true },
+			],
+		},
+	],
+};
+
+renderApp(<MusicNotation data={data} highlightClassName="highlight" />);

--- a/apps/react/tests/music-notation-accidentals-e-major.spec.ts
+++ b/apps/react/tests/music-notation-accidentals-e-major.spec.ts
@@ -1,0 +1,9 @@
+import { test, captureScreenshot } from './helpers';
+
+test('MusicNotation E major accidentals screenshot', async ({ page }) => {
+	await captureScreenshot(
+		page,
+		'/tests/music-notation-accidentals-e-major-test.html',
+		'music-notation-accidentals-e-major.png',
+	);
+});


### PR DESCRIPTION
## Summary
- prevent VexFlow from rendering accidentals for notes already in the key signature
- add standalone screenshot test demonstrating E major accidentals

## Testing
- `yarn test:codex`
- `npx playwright test tests/music-notation-accidentals-e-major.spec.ts --update-snapshots` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b1544684748328a6ea9c097941f888