### PR TITLE
feat: allow deleting user flashcards

### DIFF
--- a/apps/react/src/components/FlashCard.tsx
+++ b/apps/react/src/components/FlashCard.tsx
@@ -7,6 +7,7 @@ import React, { forwardRef } from 'react';
 import { IS_TEST_ENV } from '../utils/constants';
 import { CircleHover } from './CircleHover';
 import { FlashCardEditButton } from './FlashCardEditButton';
+import { FlashCardDeleteButton } from './FlashCardDeleteButton';
 import { MultiSheetCardQuestion } from './FlashCards/MultiSheetCardQuestion';
 import { Pill } from './Pill';
 
@@ -18,6 +19,7 @@ interface FlashCardProps {
 	className?: string;
 	opacity?: number;
 	showEdit?: boolean;
+	showDelete?: boolean;
 }
 
 export interface QuestionRender {
@@ -64,7 +66,7 @@ const HideCardButton: React.FC<{ card: CardWithAttempts }> = ({ card }) => {
 };
 
 export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
-	({ card, className, opacity, placement, showEdit }, ref) => {
+	({ card, className, opacity, placement, showEdit, showDelete }, ref) => {
 		const QuestionComponent = QuestionComponentMap[card.type];
 		if (!QuestionComponent) {
 			console.error('No question component found for card type', card.type);
@@ -81,6 +83,7 @@ export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
 				}}
 			>
 				<FlashCardEditButton card={card} show={showEdit} />
+				<FlashCardDeleteButton card={card} show={showDelete} />
 				<HideCardButton card={card} />
 				<div className="text-4xl font-medium flex flex-1 justify-center items-center">
 					<QuestionComponent card={card} placement={placement} />

--- a/apps/react/src/components/FlashCardDeleteButton.tsx
+++ b/apps/react/src/components/FlashCardDeleteButton.tsx
@@ -1,0 +1,34 @@
+import { TrashIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+import { deleteCard } from 'MemoryFlashCore/src/redux/actions/delete-card-action';
+import { CardWithAttempts } from 'MemoryFlashCore/src/redux/selectors/currDeckCardsWithAttempts';
+import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
+import { CircleHover } from './CircleHover';
+import { ConfirmModal } from './modals/ConfirmModal';
+
+interface FlashCardDeleteButtonProps {
+	card: CardWithAttempts;
+	show?: boolean;
+}
+
+export const FlashCardDeleteButton: React.FC<FlashCardDeleteButtonProps> = ({ card, show }) => {
+	const user = useAppSelector((s) => s.auth.user);
+	const dispatch = useAppDispatch();
+	const [open, setOpen] = React.useState(false);
+	if (!show || !user || (card as any).userId !== user._id) return null;
+	return (
+		<>
+			<div className="absolute right-1 bottom-1">
+				<CircleHover onClick={() => setOpen(true)}>
+					<TrashIcon className="w-4 h-4" />
+				</CircleHover>
+			</div>
+			<ConfirmModal
+				isOpen={open}
+				onClose={() => setOpen(false)}
+				message="Delete this card?"
+				onConfirm={() => dispatch(deleteCard(card._id))}
+			/>
+		</>
+	);
+};

--- a/apps/react/src/screens/AllDeckCardsScreen.tsx
+++ b/apps/react/src/screens/AllDeckCardsScreen.tsx
@@ -36,10 +36,11 @@ export const AllDeckCardsScreen: React.FunctionComponent<AllDeckCardsScreenProps
 				{deck.map((card, i) => (
 					<FlashCard
 						key={card._id + i}
-						placement={'cur'}
+						placement="cur"
 						card={card}
-						className={`card-shadow-2`}
+						className="card-shadow-2"
 						showEdit
+						showDelete
 					/>
 				))}
 			</div>

--- a/apps/server/src/routes/cardsRouter.ts
+++ b/apps/server/src/routes/cardsRouter.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { isAuthenticated } from '../middleware';
-import { updateCard } from '../services/cardService';
+import { deleteCard, updateCard } from '../services/cardService';
 import { User } from 'MemoryFlashCore/src/types/User';
 
 const router = Router();
@@ -13,6 +13,15 @@ router.patch('/:id', isAuthenticated, async (req, res, next) => {
 			(req.user as User)._id.toString(),
 		);
 		return res.json({ card });
+	} catch (error) {
+		next(error);
+	}
+});
+
+router.delete('/:id', isAuthenticated, async (req, res, next) => {
+	try {
+		await deleteCard(req.params.id, (req.user as User)._id.toString());
+		return res.json({});
 	} catch (error) {
 		next(error);
 	}

--- a/apps/server/src/services/cardService.ts
+++ b/apps/server/src/services/cardService.ts
@@ -1,4 +1,5 @@
 import Course from '../models/Course';
+import Attempt from '../models/Attempt';
 import { Card } from '../models/Card';
 import { Deck } from '../models/Deck';
 import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
@@ -14,4 +15,14 @@ export async function updateCard(cardId: string, question: MultiSheetQuestion, u
 	card.question = question;
 	await card.save();
 	return card;
+}
+
+export async function deleteCard(cardId: string, userId: string) {
+	const card = await Card.findById(cardId);
+	if (!card) return;
+	const deck = await Deck.findById(card.deckId);
+	if (!deck) return;
+	const course = await Course.findById(deck.courseId);
+	if (!course || course.userId?.toString() !== userId) return;
+	await Promise.all([Card.deleteOne({ _id: cardId }), Attempt.deleteMany({ cardId })]);
 }

--- a/packages/MemoryFlashCore/src/redux/actions/delete-card-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/delete-card-action.ts
@@ -1,0 +1,17 @@
+import { cardsActions } from '../slices/cardsSlice';
+import { attemptsActions } from '../slices/attemptsSlice';
+import { AppThunk } from '../store';
+import { networkCallWithReduxState } from '../util/networkStateHelper';
+
+export const deleteCard =
+	(cardId: string): AppThunk =>
+	async (dispatch, getState, { api }) => {
+		await networkCallWithReduxState(dispatch, 'deleteCard', async () => {
+			await api.delete('/cards/' + cardId);
+			const ids = Object.values(getState().attempts.entities)
+				.filter((a) => a?.cardId === cardId)
+				.map((a) => a!._id);
+			dispatch(attemptsActions.removeMany(ids));
+			dispatch(cardsActions.remove(cardId));
+		});
+	};

--- a/packages/MemoryFlashCore/src/redux/slices/attemptsSlice.ts
+++ b/packages/MemoryFlashCore/src/redux/slices/attemptsSlice.ts
@@ -16,6 +16,7 @@ const attemptsSlice = createSlice({
 	initialState,
 	reducers: {
 		upsert: attemptsAdapter.upsertMany,
+		removeMany: attemptsAdapter.removeMany,
 	},
 });
 

--- a/packages/MemoryFlashCore/src/redux/slices/cardsSlice.ts
+++ b/packages/MemoryFlashCore/src/redux/slices/cardsSlice.ts
@@ -14,6 +14,7 @@ const cardsSlice = createSlice({
 	initialState,
 	reducers: {
 		upsert: cardAdapter.upsertMany,
+		remove: cardAdapter.removeOne,
 	},
 });
 


### PR DESCRIPTION
## Summary
- allow deleting owned flashcards from AllDeckCardsScreen
- support card deletion via Redux and server

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68b3807456dc832894a3a7acd3c4ad74