### PR TITLE
fix: restore card edit and delete actions

### DIFF
--- a/apps/react/src/components/FlashCardDeleteButton.tsx
+++ b/apps/react/src/components/FlashCardDeleteButton.tsx
@@ -2,7 +2,8 @@ import { TrashIcon } from '@heroicons/react/24/outline';
 import React from 'react';
 import { deleteCard } from 'MemoryFlashCore/src/redux/actions/delete-card-action';
 import { CardWithAttempts } from 'MemoryFlashCore/src/redux/selectors/currDeckCardsWithAttempts';
-import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
+import { useAppDispatch } from 'MemoryFlashCore/src/redux/store';
+import { useIsCardOwner } from '../utils/useIsCardOwner';
 import { CircleHover } from './CircleHover';
 import { ConfirmModal } from './modals/ConfirmModal';
 
@@ -12,10 +13,10 @@ interface FlashCardDeleteButtonProps {
 }
 
 export const FlashCardDeleteButton: React.FC<FlashCardDeleteButtonProps> = ({ card, show }) => {
-	const user = useAppSelector((s) => s.auth.user);
+	const isOwner = useIsCardOwner(card);
 	const dispatch = useAppDispatch();
 	const [open, setOpen] = React.useState(false);
-	if (!show || !user || (card as any).userId !== user._id) return null;
+	if (!show || !isOwner) return null;
 	return (
 		<>
 			<div className="absolute right-1 bottom-1">

--- a/apps/react/src/components/FlashCardEditButton.tsx
+++ b/apps/react/src/components/FlashCardEditButton.tsx
@@ -1,6 +1,6 @@
 import { PencilSquareIcon } from '@heroicons/react/24/outline';
-import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
 import { CardWithAttempts } from 'MemoryFlashCore/src/redux/selectors/currDeckCardsWithAttempts';
+import { useIsCardOwner } from '../utils/useIsCardOwner';
 import { CircleHover } from './CircleHover';
 
 interface FlashCardEditButtonProps {
@@ -9,9 +9,8 @@ interface FlashCardEditButtonProps {
 }
 
 export const FlashCardEditButton: React.FC<FlashCardEditButtonProps> = ({ card, show }) => {
-	const user = useAppSelector((state) => state.auth.user);
-
-	if (!show || !user || (card as any).userId !== user._id) return null;
+	const isOwner = useIsCardOwner(card);
+	if (!show || !isOwner) return null;
 
 	return (
 		<div className="absolute right-1 top-1">

--- a/apps/react/src/utils/useIsCardOwner.ts
+++ b/apps/react/src/utils/useIsCardOwner.ts
@@ -1,0 +1,13 @@
+import { CardWithAttempts } from 'MemoryFlashCore/src/redux/selectors/currDeckCardsWithAttempts';
+import { useAppSelector } from 'MemoryFlashCore/src/redux/store';
+
+export function useIsCardOwner(card: CardWithAttempts): boolean {
+	return useAppSelector((state) => {
+		const user = state.auth.user;
+		if (!user) return false;
+		const deck = state.decks.entities[card.deckId];
+		if (!deck) return false;
+		const course = state.courses.entities[deck.courseId];
+		return course?.userId === user._id;
+	});
+}


### PR DESCRIPTION
## Summary
- add `useIsCardOwner` hook to verify card ownership
- show edit and delete controls when user owns deck's course

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_68b3b0b9c81483289f83e08f5f52aec9