### PR TITLE
fix: load card on edit

### DIFF
--- a/apps/react/src/components/notation/NotationSettings.tsx
+++ b/apps/react/src/components/notation/NotationSettings.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { KeySelector } from '../KeySelector';
 import { majorKeys } from 'MemoryFlashCore/src/lib/notes';
-import { defaultSettings, NotationSettingsState } from './defaultSettings';
+import { NotationSettingsState } from './defaultSettings';
 import { NoteSettings } from './NoteSettings';
 import { SettingsSection } from './SettingsSection';
 import { RangeSettings } from './RangeSettings';
@@ -9,47 +9,40 @@ import { CardTypeOptions } from './CardTypeOptions';
 import { BarsSetting } from './BarsSetting';
 
 interface NotationSettingsProps {
+	settings: NotationSettingsState;
 	onChange: (settings: NotationSettingsState) => void;
 }
 
-export const NotationSettings: React.FC<NotationSettingsProps> = ({ onChange }) => {
-	const [state, setState] = useState<NotationSettingsState>(defaultSettings);
-
-	useEffect(() => {
-		onChange(state);
-	}, [state]);
-
-	const update = (changes: Partial<NotationSettingsState>) =>
-		setState((prev) => {
-			let next: NotationSettingsState = { ...prev, ...changes };
-			if (changes.keySig) {
-				const idx = majorKeys.indexOf(changes.keySig);
-				// select only the new key, deselect others
-				next.selected = next.selected.map((_, i) => i === idx);
-			}
-			return next;
-		});
+export const NotationSettings: React.FC<NotationSettingsProps> = ({ settings, onChange }) => {
+	const update = (changes: Partial<NotationSettingsState>) => {
+		let next: NotationSettingsState = { ...settings, ...changes };
+		if (changes.keySig) {
+			const idx = majorKeys.indexOf(changes.keySig);
+			next.selected = next.selected.map((_, i) => i === idx);
+		}
+		onChange(next);
+	};
 
 	return (
 		<div className="space-y-4">
 			<NoteSettings
-				keySig={state.keySig}
-				trebleDur={state.trebleDur}
-				bassDur={state.bassDur}
+				keySig={settings.keySig}
+				trebleDur={settings.trebleDur}
+				bassDur={settings.bassDur}
 				onChange={update}
 			/>
-			<RangeSettings lowest={state.lowest} highest={state.highest} onChange={update} />
-			<BarsSetting bars={state.bars} setBars={(n) => update({ bars: n })} />
+			<RangeSettings lowest={settings.lowest} highest={settings.highest} onChange={update} />
+			<BarsSetting bars={settings.bars} setBars={(n) => update({ bars: n })} />
 			<SettingsSection title="Keys">
 				<KeySelector
-					selected={state.selected}
+					selected={settings.selected}
 					onChange={(selected) => update({ selected })}
 				/>
 			</SettingsSection>
 			<CardTypeOptions
-				cardType={state.cardType}
-				textPrompt={state.textPrompt}
-				preview={state.preview}
+				cardType={settings.cardType}
+				textPrompt={settings.textPrompt}
+				preview={settings.preview}
 				onChange={update}
 			/>
 		</div>

--- a/apps/react/src/screens/NotationInputScreen.tsx
+++ b/apps/react/src/screens/NotationInputScreen.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store'
 import { MusicRecorder } from 'MemoryFlashCore/src/lib/MusicRecorder';
 import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
 import { questionsForAllMajorKeys } from 'MemoryFlashCore/src/lib/multiKeyTransposer';
+import { majorKeys } from 'MemoryFlashCore/src/lib/notes';
 import { addCardsToDeck } from 'MemoryFlashCore/src/redux/actions/add-cards-to-deck';
 import { updateCard } from 'MemoryFlashCore/src/redux/actions/update-card-action';
 import { setPresentationMode } from 'MemoryFlashCore/src/redux/actions/set-presentation-mode';
@@ -37,9 +38,14 @@ export const NotationInputScreen = () => {
 
 	useEffect(() => {
 		if (card && card.type === CardTypeEnum.MultiSheet) {
+			const text = card.question.presentationModes?.find((p) => p.id === 'Text Prompt');
+			const idx = majorKeys.indexOf(card.question.key);
 			setSettings((prev) => ({
 				...prev,
 				keySig: card.question.key,
+				selected: majorKeys.map((_, i) => i === idx),
+				cardType: text ? 'Text Prompt' : 'Sheet Music',
+				textPrompt: text?.text || '',
 			}));
 		}
 	}, [card]);
@@ -62,10 +68,16 @@ export const NotationInputScreen = () => {
 	const data = useMemo(() => {
 		if (!shallowEqual(prevMidiNotesRef.current, midiNotes)) {
 			recorderRef.current.addMidiNotes(midiNotes);
-			prevMidiNotesRef.current = [...midiNotes]; // Copy to store content
+			prevMidiNotesRef.current = [...midiNotes];
+		}
+		if (recorderRef.current.totalBeatsRecorded > 0) {
+			return recorderRef.current.buildQuestion(settings.keySig);
+		}
+		if (card && card.type === CardTypeEnum.MultiSheet) {
+			return card.question;
 		}
 		return recorderRef.current.buildQuestion(settings.keySig);
-	}, [midiNotes, settings.keySig]);
+	}, [midiNotes, settings.keySig, card]);
 	const previewsAll = questionsForAllMajorKeys(data, settings.lowest, settings.highest);
 	const previews = previewsAll.filter((_, i) => settings.selected[i]);
 
@@ -104,7 +116,7 @@ export const NotationInputScreen = () => {
 
 	return (
 		<Layout subtitle="Notation Input">
-			<NotationSettings onChange={setSettings} />
+			<NotationSettings settings={settings} onChange={setSettings} />
 			<NotationPreviewList
 				previews={previews}
 				cardType={settings.cardType}

--- a/apps/react/tests/custom-deck-notation-to-study.spec.ts
+++ b/apps/react/tests/custom-deck-notation-to-study.spec.ts
@@ -96,6 +96,15 @@ test('Create custom deck, add notation and text cards, then study', async ({ pag
 	await page.getByText(promptText, { exact: true }).waitFor();
 	await expect(output).toHaveScreenshot('custom-deck-notation-to-study-list.png', screenshotOpts);
 
+	// Edit text card and ensure it loads with existing data
+	await page
+		.locator('.card-container', { hasText: promptText })
+		.locator('a[href*="/edit/"]')
+		.click();
+	await page.waitForURL(new RegExp(`/study/${deckId}/edit/`));
+	await expect(page.getByRole('button', { name: 'Text Prompt' })).toBeVisible();
+	await expect(page.locator('#text-prompt')).toHaveValue(promptText);
+
 	// Go back to study screen and test the card
 	await page.goto(`/study/${deckId}`);
 	// Wait for the page to load


### PR DESCRIPTION
## Summary
- preload existing card data when editing from list view
- make notation settings controlled and preserve text-card mode
- test editing card loads NotationInputScreen with data

## Testing
- `yarn test:codex`
- `yarn workspace MemoryFlashReact test:screenshots apps/react/tests/custom-deck-notation-to-study.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3f66414208328aad63ea8ff5a7eb7