### PR TITLE
Fix scheduler after card deletion

### DIFF
--- a/packages/MemoryFlashCore/src/redux/actions/delete-card-action.ts
+++ b/packages/MemoryFlashCore/src/redux/actions/delete-card-action.ts
@@ -1,5 +1,6 @@
 import { cardsActions } from '../slices/cardsSlice';
 import { attemptsActions } from '../slices/attemptsSlice';
+import { schedulerActions } from '../slices/schedulerSlice';
 import { AppThunk } from '../store';
 import { networkCallWithReduxState } from '../util/networkStateHelper';
 
@@ -13,5 +14,6 @@ export const deleteCard =
 				.map((a) => a!._id);
 			dispatch(attemptsActions.removeMany(ids));
 			dispatch(cardsActions.remove(cardId));
+			dispatch(schedulerActions.removeCard(cardId));
 		});
 	};

--- a/packages/MemoryFlashCore/src/redux/selectors/scheduledCardsSelector.ts
+++ b/packages/MemoryFlashCore/src/redux/selectors/scheduledCardsSelector.ts
@@ -7,14 +7,14 @@ const selectScheduler = (state: ReduxState) => state.scheduler;
 export const scheduledCardsSelector = createSelector(
 	[currDeckWithAttemptsSelector, selectScheduler],
 	(currentDeck, schedulerRedux) => {
-		return schedulerRedux.nextCards.map((cardId) => currentDeck[cardId]);
+		return schedulerRedux.nextCards.map((cardId) => currentDeck[cardId]).filter(Boolean);
 	},
 );
 
 export const answeredCardsSelector = createSelector(
 	[currDeckWithAttemptsSelector, selectScheduler],
 	(currentDeck, schedulerRedux) => {
-		return schedulerRedux.answeredCards.map((cardId) => currentDeck[cardId]);
+		return schedulerRedux.answeredCards.map((cardId) => currentDeck[cardId]).filter(Boolean);
 	},
 );
 

--- a/packages/MemoryFlashCore/src/redux/slices/schedulerSlice.test.ts
+++ b/packages/MemoryFlashCore/src/redux/slices/schedulerSlice.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { schedulerReducer, schedulerActions, SchedulerState } from './schedulerSlice';
+import { scheduledCardsSelector } from '../selectors/scheduledCardsSelector';
+import { CardWithAttempts } from '../selectors/currDeckCardsWithAttempts';
+import { CardTypeEnum, AnswerType, StaffEnum } from '../../types/Cards';
+
+const baseState: SchedulerState = {
+	batchId: 'b',
+	currStartTime: 0,
+	nextCards: [],
+	answeredCards: [],
+	multiPartCardIndex: 0,
+};
+
+describe('schedulerSlice', () => {
+	it('removes card from queues and advances current card', () => {
+		const state: SchedulerState = {
+			...baseState,
+			currCard: 'a',
+			nextCards: ['a', 'b'],
+			answeredCards: ['c'],
+		};
+		const next = schedulerReducer(state, schedulerActions.removeCard('a'));
+		expect(next.currCard).to.equal('b');
+		expect(next.nextCards).to.deep.equal(['b']);
+		expect(next.answeredCards).to.deep.equal(['c']);
+	});
+
+	it('scheduledCardsSelector ignores missing ids', () => {
+		const deck: { [key: string]: CardWithAttempts } = {
+			b: {
+				_id: 'b',
+				uid: 'u',
+				deckId: 'd1',
+				type: CardTypeEnum.BasicSheet,
+				question: { staff: StaffEnum.Treble, notes: [] },
+				answer: { type: AnswerType.AnyOctave, notes: [] },
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				attempts: [],
+			},
+		};
+		const scheduler: SchedulerState = {
+			...baseState,
+			nextCards: ['a', 'b'],
+		};
+		const result = scheduledCardsSelector.resultFunc(deck, scheduler);
+		expect(result.map((c) => c._id)).to.deep.equal(['b']);
+	});
+});

--- a/packages/MemoryFlashCore/src/redux/slices/schedulerSlice.ts
+++ b/packages/MemoryFlashCore/src/redux/slices/schedulerSlice.ts
@@ -75,6 +75,13 @@ const schedulerSlice = createSlice({
 				state.nextCards.unshift(action.payload);
 			}
 		},
+		removeCard(state, action: PayloadAction<string>) {
+			state.nextCards = state.nextCards.filter((id) => id !== action.payload);
+			state.answeredCards = state.answeredCards.filter((id) => id !== action.payload);
+			if (state.currCard === action.payload) {
+				pickupNextCard(state);
+			}
+		},
 		dequeueNextCard,
 	},
 });


### PR DESCRIPTION
## Summary
- remove deleted cards from scheduler queues
- drop stale card references on delete
- ignore missing cards when selecting scheduler data
- add tests covering scheduler card removal and selector filtering

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68b4dcef85088328b76e63fd1621257e