### PR TITLE
fix: enforce bar limit across clefs

### DIFF
--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.test.ts
@@ -32,6 +32,16 @@ describe('MusicRecorder', () => {
 		expect(r.notes.length).to.equal(4);
 	});
 
+	it('ignores cross-clef notes after one bar', () => {
+		const r = new MusicRecorder('q');
+		for (const n of [60, 48, 60, 48, 60]) {
+			r.addMidiNotes([n]);
+			r.addMidiNotes([]);
+		}
+		expect(r.notes.length).to.equal(4);
+		expect(r.totalBeatsRecorded).to.equal(4);
+	});
+
 	it('records two measures when configured', () => {
 		const r = new MusicRecorder('q', 'C4', 'q', 2);
 		for (const n of [60, 62, 64, 65, 67, 69, 71, 72]) {

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -69,7 +69,7 @@ export class MusicRecorder {
 	private addEvent(staff: StaffEnum, midi: number[], start: number) {
 		const state = this.staff[staff as StaffKey];
 		const beats = durationBeats[state.duration];
-		if (state.beats + beats > this._maxBeats) return false;
+		if (start + beats > this._maxBeats) return false;
 		state.events.push({ start, notes: [...midi], duration: state.duration });
 		state.beats = start + beats;
 		return true;


### PR DESCRIPTION
## Summary
- prevent MusicRecorder from adding events beyond configured bar count
- add regression test ensuring cross-clef notes don't overflow a single bar

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68b53880cf2c832894164509ccc7e523