### PR TITLE
Allow unordered note order for cross-clef validator

### DIFF
--- a/apps/react/src/components/answer-validators/UnExactMultiAnswerValidator.tsx
+++ b/apps/react/src/components/answer-validators/UnExactMultiAnswerValidator.tsx
@@ -26,7 +26,12 @@ export const UnExactMultiAnswerValidator: React.FC<{ card: Card }> = ({ card: _c
 	const getChromaNotesForPart = (index: number): number[] =>
 		card.question.voices
 			.flatMap((voice) => voice.stack[index]?.notes ?? [])
-			.map((note) => Note.chroma(note.name + note.octave));
+			.map((note) => {
+				const name = note.name + note.octave;
+				return { midi: Midi.toMidi(name)!, chroma: Note.chroma(name) };
+			})
+			.sort((a, b) => a.midi - b.midi)
+			.map((n) => n.chroma);
 
 	const answerPartNotesChroma = getChromaNotesForPart(multiPartCardIndex);
 	const firstPartNotesChroma = getChromaNotesForPart(0);

--- a/apps/server/src/services/card-generators/create-two-handed-cards-from-progressions.ts
+++ b/apps/server/src/services/card-generators/create-two-handed-cards-from-progressions.ts
@@ -1,5 +1,6 @@
 import { AnswerType, CardTypeEnum, StaffEnum } from 'MemoryFlashCore/src/types/Cards';
 import { MultiSheetCard, StackedNotes } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { Midi } from 'tonal';
 import { PresentationMode } from 'MemoryFlashCore/src/types/PresentationMode';
 import { generateProgressionsFromRomanNumerals } from './ii-V-i/ii-V-I-progression-generators';
 
@@ -20,9 +21,20 @@ export function createTwoHandedCardsFromProgressions(
 		const bassStack: StackedNotes[] = [];
 		const trebleStack: StackedNotes[] = [];
 
-		progression.voice.forEach((voice, i) => {
-			bassStack.push({ ...voice, notes: voice.notes.slice(0, numBassNotes) });
-			trebleStack.push({ ...voice, notes: voice.notes.slice(numBassNotes) });
+		const sortNotes = (notes: StackedNotes['notes']) =>
+			[...notes].sort(
+				(a, b) => Midi.toMidi(a.name + a.octave)! - Midi.toMidi(b.name + b.octave)!,
+			);
+
+		progression.voice.forEach((voice) => {
+			bassStack.push({
+				...voice,
+				notes: sortNotes(voice.notes.slice(0, numBassNotes)),
+			});
+			trebleStack.push({
+				...voice,
+				notes: sortNotes(voice.notes.slice(numBassNotes)),
+			});
 		});
 
 		return {

--- a/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
+++ b/packages/MemoryFlashCore/src/lib/MusicRecorder.ts
@@ -70,7 +70,8 @@ export class MusicRecorder {
 		const state = this.staff[staff as StaffKey];
 		const beats = durationBeats[state.duration];
 		if (start + beats > this._maxBeats) return false;
-		state.events.push({ start, notes: [...midi], duration: state.duration });
+		const notes = [...midi].sort((a, b) => a - b);
+		state.events.push({ start, notes, duration: state.duration });
 		state.beats = start + beats;
 		return true;
 	}
@@ -83,6 +84,7 @@ export class MusicRecorder {
 		for (const n of midi) {
 			if (!existing.has(n)) event.notes.push(n);
 		}
+		event.notes.sort((a, b) => a - b);
 	}
 
 	private rebuildNotes() {
@@ -96,8 +98,13 @@ export class MusicRecorder {
 				for (const n of e.notes) {
 					if (!existing.has(n)) last.notes.push(n);
 				}
+				last.notes.sort((a, b) => a - b);
 			} else {
-				merged.push({ start: e.start, notes: [...e.notes], duration: e.duration });
+				merged.push({
+					start: e.start,
+					notes: [...e.notes].sort((a, b) => a - b),
+					duration: e.duration,
+				});
 			}
 		}
 		this.notes = merged.map((e) => ({
@@ -193,8 +200,9 @@ export class MusicRecorder {
 				stack.push(...createRestDurations(e.start - beat));
 				beat = e.start;
 			}
+			const notes = [...e.notes].sort((a, b) => a - b);
 			stack.push({
-				notes: e.notes.map((m) => this.toSheetNote(m, key)),
+				notes: notes.map((m) => this.toSheetNote(m, key)),
 				duration: e.duration,
 			});
 			beat = e.start + durationBeats[e.duration];


### PR DESCRIPTION
## Summary
- sort recorded and generated chord notes by MIDI value
- ensure validator checks answers in MIDI order and warns when notes are out of order

## Testing
- `yarn test:codex` *(fails: Timeout of 10000ms exceeded; MongooseError: Can't call `openUri()` on an active connection with different connection strings)*

------
https://chatgpt.com/codex/tasks/task_e_68c2778c72e48328bb4cf93562324737