### PR TITLE
refactor: use clsx in dropdown components

### DIFF
--- a/apps/react/src/components/Dropdown.tsx
+++ b/apps/react/src/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuButton, MenuItem, MenuItems, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import clsx from 'clsx';
 import React, { Fragment } from 'react';
 
 interface DropdownItem {
@@ -11,10 +12,6 @@ interface DropdownProps {
 	label: React.ReactNode;
 	items: DropdownItem[];
 	onButtonClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined) => void;
-}
-
-function classNames(...classes: string[]) {
-	return classes.filter(Boolean).join(' ');
 }
 
 const Dropdown: React.FC<DropdownProps> = ({ label, items, onButtonClick }) => {
@@ -45,7 +42,7 @@ const Dropdown: React.FC<DropdownProps> = ({ label, items, onButtonClick }) => {
 								{({ focus }) => (
 									<button
 										onClick={item.onClick}
-										className={classNames(
+										className={clsx(
 											focus ? 'bg-gray-50 text-gray-900' : 'text-gray-700',
 											'block w-full px-4 py-2 text-left text-sm',
 										)}

--- a/apps/react/src/components/DropdownMenu.tsx
+++ b/apps/react/src/components/DropdownMenu.tsx
@@ -1,4 +1,5 @@
 import { MenuItem, MenuItems, Transition } from '@headlessui/react';
+import clsx from 'clsx';
 import React, { Fragment } from 'react';
 
 export interface DropdownItem {
@@ -8,10 +9,6 @@ export interface DropdownItem {
 
 interface DropdownMenuProps {
 	items: DropdownItem[];
-}
-
-function classNames(...classes: string[]) {
-	return classes.filter(Boolean).join(' ');
 }
 
 export const DropdownMenu: React.FC<DropdownMenuProps> = ({ items }) => (
@@ -31,7 +28,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({ items }) => (
 						{({ focus }) => (
 							<button
 								onClick={item.onClick}
-								className={classNames(
+								className={clsx(
 									focus ? 'bg-gray-50 text-gray-900' : 'text-gray-700',
 									'block w-full px-4 py-2 text-left text-sm',
 								)}


### PR DESCRIPTION
## Summary
- import `clsx` in Dropdown and DropdownMenu
- drop duplicate `classNames` helpers in favor of shared utility

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68c3c2d163dc83289f59fce2208c5a1b