### PR TITLE
chore: cache yarn dependencies in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,18 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'
 
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      .yarn/cache
+                      **/node_modules
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+
             - name: Install dependencies
-              run: yarn install
+              run: yarn install --immutable --mode=skip-build
 
             - name: Run tsc
               uses: icrawl/action-tsc@v1


### PR DESCRIPTION
## Summary
- cache yarn and node modules in test workflow
- install dependencies with `yarn install --immutable --mode=skip-build`

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68c3ca3f06c08328ab3bbde467457096