### PR TITLE
feat: add timeline-based MIDI validator

### DIFF
--- a/apps/react/src/components/answer-validators/ExactMultiAnswerValidator.tsx
+++ b/apps/react/src/components/answer-validators/ExactMultiAnswerValidator.tsx
@@ -1,4 +1,4 @@
-import { Note } from 'tonal';
+import { useMemo, useState } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { recordAttempt } from 'MemoryFlashCore/src/redux/actions/record-attempt-action';
 import { midiActions } from 'MemoryFlashCore/src/redux/slices/midiSlice';
@@ -6,81 +6,43 @@ import { schedulerActions } from 'MemoryFlashCore/src/redux/slices/schedulerSlic
 import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
 import { Card } from 'MemoryFlashCore/src/types/Cards';
 import { MultiSheetCard } from 'MemoryFlashCore/src/types/MultiSheetCard';
-import { filterNullOrUndefined } from 'MemoryFlashCore/src/lib/filterNullOrUndefined';
-import { useState } from 'react';
-import { computeTieSkipAdvance, notesForPartExact } from './tieUtils';
+import { buildNoteTimeline } from './tieUtils';
 
 export const ExactMultiAnswerValidator: React.FC<{ card: Card }> = ({ card: _card }) => {
 	const card = _card as MultiSheetCard;
-
+	const timeline = useMemo(() => buildNoteTimeline(card), [card]);
 	const dispatch = useAppDispatch();
-	const onNotes = useAppSelector((state) => state.midi.notes);
-	const waitingUntilEmpty = useAppSelector((state) => state.midi.waitingUntilEmpty);
-	const multiPartCardIndex = useAppSelector((state) => state.scheduler.multiPartCardIndex);
-	const onNotesMidi = onNotes.map((note) => note.number);
+	const onNotes = useAppSelector((s) => s.midi.notes).map((n) => n.number);
+	const waitingUntilEmpty = useAppSelector((s) => s.midi.waitingUntilEmpty);
+	const multiPartCardIndex = useAppSelector((s) => s.scheduler.multiPartCardIndex);
+	const [lastCheckpointIndex, setLastCheckpointIndex] = useState(0);
 
-	const [wrongIndex, setWrongIndex] = useState(-1);
-
-	// Helper function to get MIDI notes for a specific part index
-	const getNotesForPart = (index: number) => notesForPartExact(card, index);
-
-	const answerPartNotesMidi = getNotesForPart(multiPartCardIndex);
-	const firstPartNotesMidi = getNotesForPart(0);
-
-	// Helper function to check if played notes match target notes (order-insensitive)
-	const areNotesMatching = (playedNotes: number[], targetNotes: number[]): boolean => {
-		return (
-			playedNotes.length === targetNotes.length &&
-			playedNotes.every((note) => targetNotes.includes(note))
-		);
+	const resetTo = (idx: number) => {
+		dispatch(schedulerActions.startFromBeginningOfCurrentCard());
+		for (let i = 0; i < idx; i++) dispatch(schedulerActions.incrementMultiPartCardIndex());
 	};
 
 	useDeepCompareEffect(() => {
 		if (waitingUntilEmpty) return;
-
-		// Allow restarting from the first index if the first part is played
-		if (
-			multiPartCardIndex != 0 &&
-			wrongIndex == multiPartCardIndex &&
-			areNotesMatching(onNotesMidi, firstPartNotesMidi)
-		) {
-			console.log('[scheduler] Restarting from the first part');
-			dispatch(schedulerActions.startFromBeginningOfCurrentCard());
-			setWrongIndex(-1);
-			return;
-		}
-
-		// Validate notes for the current part
-		if (!onNotesMidi.every((note) => answerPartNotesMidi.includes(note))) {
+		const state = timeline[multiPartCardIndex];
+		if (!state) return;
+		const expected = [...state.startNotes, ...state.carryNotes];
+		const allCarryHeld = state.carryNotes.every((n) => onNotes.includes(n));
+		const noUnexpected = onNotes.every((n) => expected.includes(n));
+		if (!allCarryHeld || !noUnexpected) {
 			dispatch(recordAttempt(false));
-			setWrongIndex(multiPartCardIndex);
-			dispatch(
-				midiActions.addWrongNote(
-					onNotesMidi.find((note) => !answerPartNotesMidi.includes(note))!,
-				),
-			);
+			resetTo(lastCheckpointIndex);
+			dispatch(midiActions.waitUntilEmpty());
 			return;
 		}
-
-		// Check if the correct number of notes have been played
-		if (onNotesMidi.length === answerPartNotesMidi.length) {
-			dispatch(midiActions.waitUntilEmpty());
-			const { nextIndex, isCompleted } = computeTieSkipAdvance(
-				card,
-				multiPartCardIndex,
-				(idx) => getNotesForPart(idx),
-			);
-			if (isCompleted) {
-				console.log('Correct card!');
+		if (onNotes.length === expected.length && allCarryHeld) {
+			setLastCheckpointIndex(multiPartCardIndex);
+			if (multiPartCardIndex === timeline.length - 1) {
 				dispatch(recordAttempt(true));
 			} else {
-				// advance to nextIndex from current
-				const steps = nextIndex - multiPartCardIndex;
-				for (let i = 0; i < steps; i++)
-					dispatch(schedulerActions.incrementMultiPartCardIndex());
+				dispatch(schedulerActions.incrementMultiPartCardIndex());
 			}
 		}
-	}, [onNotesMidi, answerPartNotesMidi, waitingUntilEmpty]);
-
+	}, [onNotes, waitingUntilEmpty, multiPartCardIndex, timeline]);
 	return null;
 };

--- a/apps/react/src/components/answer-validators/tieUtils.ts
+++ b/apps/react/src/components/answer-validators/tieUtils.ts
@@ -1,37 +1,62 @@
 import { Note } from 'tonal';
 import { MultiSheetCard } from 'MemoryFlashCore/src/types/MultiSheetCard';
 
-export type NoteProjection = number[];
-
-export function notesForPartExact(card: MultiSheetCard, index: number): number[] {
-	const notes = card.question.voices
-		.flatMap((voice) => voice.stack[index]?.notes ?? [])
-		.map((n) => Note.midi(n.name + n.octave))
-		.filter((n): n is number => typeof n === 'number');
-	return notes.slice().sort((a, b) => a - b);
+export interface ChordState {
+	startNotes: number[];
+	carryNotes: number[];
+	releaseNotes: number[];
 }
 
-export function arraysEqual(a: number[], b: number[]) {
-	if (a.length !== b.length) return false;
-	for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-	return true;
-}
+const DURATION_TICKS: Record<string, number> = { '16': 1, '8': 2, q: 4, h: 8, w: 16 };
 
-export function computeTieSkipAdvance(
-	card: MultiSheetCard,
-	currentIndex: number,
-	project: (idx: number) => NoteProjection,
-): { nextIndex: number; isCompleted: boolean } {
-	const lastIndex = card.question.voices[0].stack.length - 1;
-	let idx = currentIndex;
-	const current = project(idx);
-	while (true) {
-		if (idx >= lastIndex) return { nextIndex: idx, isCompleted: true };
-		const next = project(idx + 1);
-		if (arraysEqual(current, next)) {
-			idx += 1;
-			continue;
-		}
-		return { nextIndex: idx + 1, isCompleted: idx + 1 > lastIndex };
-	}
-}
+const parseDuration = (d: string) => {
+	const dotted = d.endsWith('d');
+	const base = DURATION_TICKS[dotted ? d.slice(0, -1) : d] ?? 0;
+	return dotted ? (base * 3) / 2 : base;
+};
+
+const collectEvents = (card: MultiSheetCard) => {
+	const events: Record<number, { start: number[]; end: number[] }> = {};
+	card.question.voices.forEach((voice) => {
+		let tick = 0;
+		voice.stack.forEach((st) => {
+			const dur = parseDuration(st.duration);
+			if (st.notes?.length && !st.rest) {
+				const mids = st.notes
+					.map((n) => Note.midi(n.name + n.octave))
+					.filter((n): n is number => typeof n === 'number');
+				events[tick] ??= { start: [], end: [] };
+				events[tick].start.push(...mids);
+				events[tick + dur] ??= { start: [], end: [] };
+				events[tick + dur].end.push(...mids);
+			}
+			tick += dur;
+		});
+	});
+	return events;
+};
+
+const eventsToTimeline = (
+	events: Record<number, { start: number[]; end: number[] }>,
+): ChordState[] => {
+	const ticks = Object.keys(events)
+		.map(Number)
+		.sort((a, b) => a - b);
+	const timeline: ChordState[] = [];
+	let held: number[] = [];
+	ticks.forEach((t) => {
+		const ev = events[t];
+		held = held.filter((n) => !ev.end.includes(n));
+		const carry = [...held].sort((a, b) => a - b);
+		const start = ev.start.slice().sort((a, b) => a - b);
+		timeline.push({
+			startNotes: start,
+			carryNotes: carry,
+			releaseNotes: ev.end.slice().sort((a, b) => a - b),
+		});
+		held = [...carry, ...start].sort((a, b) => a - b);
+	});
+	return timeline;
+};
+
+export const buildNoteTimeline = (card: MultiSheetCard) => eventsToTimeline(collectEvents(card));


### PR DESCRIPTION
## Summary
- build timeline checkpoints for MultiSheet cards
- validate MIDI input against chord states with error recovery

## Testing
- `yarn test:codex`


------
https://chatgpt.com/codex/tasks/task_e_68c66d5ef45c8328b71ece47e05f6b4b