### PR TITLE
feat: add timeline validator with checkpoints

### DIFF
--- a/apps/react/src/components/answer-validators/tieUtils.test.ts
+++ b/apps/react/src/components/answer-validators/tieUtils.test.ts
@@ -1,0 +1,43 @@
+import { buildNoteTimeline } from './tieUtils';
+import { MultiSheetCard } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { CardTypeEnum, AnswerType, StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+
+describe('buildNoteTimeline', () => {
+	it('handles rests and sustained notes', () => {
+		const card: MultiSheetCard = {
+			uid: '1',
+			type: CardTypeEnum.MultiSheet,
+			question: {
+				key: 'G',
+				voices: [
+					{
+						staff: StaffEnum.Treble,
+						stack: [
+							{ notes: [], duration: 'q', rest: true },
+							{ notes: [{ name: 'B', octave: 3 }], duration: '16' },
+							{ notes: [{ name: 'A', octave: 3 }], duration: '8' },
+							{ notes: [{ name: 'G', octave: 3 }], duration: '8' },
+							{ notes: [{ name: 'E', octave: 3 }], duration: '16' },
+							{ notes: [{ name: 'D', octave: 3 }], duration: 'qd' },
+						],
+					},
+					{
+						staff: StaffEnum.Bass,
+						stack: [
+							{ notes: [{ name: 'G', octave: 2 }], duration: 'hd' },
+							{ notes: [{ name: 'G', octave: 2 }], duration: 'q' },
+						],
+					},
+				],
+				presentationModes: [],
+			},
+			answer: { type: AnswerType.ExactMulti },
+		};
+
+		const timeline = buildNoteTimeline(card);
+		expect(timeline).toHaveLength(7);
+		expect(timeline[0]).toEqual({ startNotes: [43], carryNotes: [], releaseNotes: [] });
+		expect(timeline[1]).toEqual({ startNotes: [59], carryNotes: [43], releaseNotes: [59] });
+		expect(timeline[5]).toEqual({ startNotes: [50], carryNotes: [43], releaseNotes: [43] });
+	});
+});

--- a/packages/MemoryFlashCore/src/types/MultiSheetCard.ts
+++ b/packages/MemoryFlashCore/src/types/MultiSheetCard.ts
@@ -10,7 +10,7 @@ export type Voice = {
 };
 export type StackedNotes = {
 	notes: SheetNote[];
-	duration: 'w' | 'h' | 'q' | '8' | '16' | '32' | '64';
+	duration: 'w' | 'h' | 'q' | '8' | '16' | '32' | '64' | 'wd' | 'hd' | 'qd';
 	chordName?: string;
 	rest?: boolean;
 };


### PR DESCRIPTION
## Summary
- build timeline checkpoints with start, carry, and release notes
- validate MIDI input against checkpoints with rollback on errors
- cover note timeline building in tests

## Testing
- `yarn test:codex` *(fails: This project's package.json defines "packageManager": "yarn@4.9.2". However the current global version of Yarn is 1.22.22.)*


------
https://chatgpt.com/codex/tasks/task_e_68c66d5ef45c8328b71ece47e05f6b4b