### PR TITLE
feat: add event-based validator engine

### DIFF
--- a/apps/react/src/components/answer-validators/ExactMultiAnswerValidator.tsx
+++ b/apps/react/src/components/answer-validators/ExactMultiAnswerValidator.tsx
@@ -1,86 +1,26 @@
-import { Note } from 'tonal';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { recordAttempt } from 'MemoryFlashCore/src/redux/actions/record-attempt-action';
-import { midiActions } from 'MemoryFlashCore/src/redux/slices/midiSlice';
-import { schedulerActions } from 'MemoryFlashCore/src/redux/slices/schedulerSlice';
+import { useMemo } from 'react';
 import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
 import { Card } from 'MemoryFlashCore/src/types/Cards';
 import { MultiSheetCard } from 'MemoryFlashCore/src/types/MultiSheetCard';
-import { filterNullOrUndefined } from 'MemoryFlashCore/src/lib/filterNullOrUndefined';
-import { useState } from 'react';
-import { computeTieSkipAdvance, notesForPartExact } from './tieUtils';
+import { buildScoreTimeline } from 'MemoryFlashCore/src/lib/scoreTimeline';
+import { ValidatorEngine } from 'MemoryFlashCore/src/lib/ValidatorEngine';
 
 export const ExactMultiAnswerValidator: React.FC<{ card: Card }> = ({ card: _card }) => {
 	const card = _card as MultiSheetCard;
-
 	const dispatch = useAppDispatch();
-	const onNotes = useAppSelector((state) => state.midi.notes);
-	const waitingUntilEmpty = useAppSelector((state) => state.midi.waitingUntilEmpty);
-	const multiPartCardIndex = useAppSelector((state) => state.scheduler.multiPartCardIndex);
-	const onNotesMidi = onNotes.map((note) => note.number);
-
-	const [wrongIndex, setWrongIndex] = useState(-1);
-
-	// Helper function to get MIDI notes for a specific part index
-	const getNotesForPart = (index: number) => notesForPartExact(card, index);
-
-	const answerPartNotesMidi = getNotesForPart(multiPartCardIndex);
-	const firstPartNotesMidi = getNotesForPart(0);
-
-	// Helper function to check if played notes match target notes (order-insensitive)
-	const areNotesMatching = (playedNotes: number[], targetNotes: number[]): boolean => {
-		return (
-			playedNotes.length === targetNotes.length &&
-			playedNotes.every((note) => targetNotes.includes(note))
-		);
-	};
-
+	const onNotes = useAppSelector((s) => s.midi.notes);
+	const waiting = useAppSelector((s) => s.midi.waitingUntilEmpty);
+	const index = useAppSelector((s) => s.scheduler.multiPartCardIndex);
+	const timeline = useMemo(() => buildScoreTimeline(card), [card]);
+	const engine = useMemo(() => new ValidatorEngine(timeline), [timeline]);
 	useDeepCompareEffect(() => {
-		if (waitingUntilEmpty) return;
-
-		// Allow restarting from the first index if the first part is played
-		if (
-			multiPartCardIndex != 0 &&
-			wrongIndex == multiPartCardIndex &&
-			areNotesMatching(onNotesMidi, firstPartNotesMidi)
-		) {
-			console.log('[scheduler] Restarting from the first part');
-			dispatch(schedulerActions.startFromBeginningOfCurrentCard());
-			setWrongIndex(-1);
-			return;
-		}
-
-		// Validate notes for the current part
-		if (!onNotesMidi.every((note) => answerPartNotesMidi.includes(note))) {
-			dispatch(recordAttempt(false));
-			setWrongIndex(multiPartCardIndex);
-			dispatch(
-				midiActions.addWrongNote(
-					onNotesMidi.find((note) => !answerPartNotesMidi.includes(note))!,
-				),
-			);
-			return;
-		}
-
-		// Check if the correct number of notes have been played
-		if (onNotesMidi.length === answerPartNotesMidi.length) {
-			dispatch(midiActions.waitUntilEmpty());
-			const { nextIndex, isCompleted } = computeTieSkipAdvance(
-				card,
-				multiPartCardIndex,
-				(idx) => getNotesForPart(idx),
-			);
-			if (isCompleted) {
-				console.log('Correct card!');
-				dispatch(recordAttempt(true));
-			} else {
-				// advance to nextIndex from current
-				const steps = nextIndex - multiPartCardIndex;
-				for (let i = 0; i < steps; i++)
-					dispatch(schedulerActions.incrementMultiPartCardIndex());
-			}
-		}
-	}, [onNotesMidi, answerPartNotesMidi, waitingUntilEmpty]);
-
+		engine.handle({
+			onNotes: onNotes.map((n) => n.number),
+			waiting,
+			index,
+			dispatch,
+		});
+	}, [onNotes, waiting, index]);
 	return null;
 };

--- a/apps/react/src/components/answer-validators/UnExactMultiAnswerValidator.tsx
+++ b/apps/react/src/components/answer-validators/UnExactMultiAnswerValidator.tsx
@@ -1,90 +1,28 @@
-import { Midi, Note } from 'tonal';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { useState } from 'react';
-import { recordAttempt } from 'MemoryFlashCore/src/redux/actions/record-attempt-action';
-import { midiActions } from 'MemoryFlashCore/src/redux/slices/midiSlice';
-import { schedulerActions } from 'MemoryFlashCore/src/redux/slices/schedulerSlice';
+import { useMemo } from 'react';
+import { Midi, Note } from 'tonal';
 import { useAppDispatch, useAppSelector } from 'MemoryFlashCore/src/redux/store';
 import { Card } from 'MemoryFlashCore/src/types/Cards';
 import { MultiSheetCard } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { buildScoreTimeline } from 'MemoryFlashCore/src/lib/scoreTimeline';
+import { ValidatorEngine } from 'MemoryFlashCore/src/lib/ValidatorEngine';
 
-// Notes may be played in any order, but the resulting chroma sequence must match the card
 export const UnExactMultiAnswerValidator: React.FC<{ card: Card }> = ({ card: _card }) => {
 	const card = _card as MultiSheetCard;
-
 	const dispatch = useAppDispatch();
-	const onNotes = useAppSelector((state) => state.midi.notes);
-	const onNotesChroma = onNotes.map((note) => Note.chroma(Midi.midiToNoteName(note.number)));
-	const onNotesMidi = onNotes.map((note) => note.number);
-	const waitingUntilEmpty = useAppSelector((state) => state.midi.waitingUntilEmpty);
-	const multiPartCardIndex = useAppSelector((state) => state.scheduler.multiPartCardIndex);
-
-	const [wrongIndex, setWrongIndex] = useState(-1);
-
-	const getChromaNotesForPart = (index: number): number[] => {
-		return card.question.voices
-			.flatMap((voice) => voice.stack[index]?.notes ?? [])
-			.map((note) => ({
-				chroma: Note.chroma(note.name + note.octave),
-				midi: Note.midi(note.name + note.octave) ?? 0,
-			}))
-			.sort((a, b) => a.midi - b.midi)
-			.map((n) => n.chroma);
-	};
-
-	const answerPartNotesChroma = getChromaNotesForPart(multiPartCardIndex);
-	const firstPartNotesChroma = getChromaNotesForPart(0);
-
-	const areArraysEqual = (array1: number[], array2: number[]): boolean => {
-		if (array1.length !== array2.length) return false;
-		for (let i = 0; i < array1.length; i++) {
-			if (array1[i] !== array2[i]) {
-				return false;
-			}
-		}
-		return true;
-	};
-
+	const onNotes = useAppSelector((s) => s.midi.notes);
+	const waiting = useAppSelector((s) => s.midi.waitingUntilEmpty);
+	const index = useAppSelector((s) => s.scheduler.multiPartCardIndex);
+	const timeline = useMemo(() => buildScoreTimeline(card), [card]);
+	const project = useMemo(() => (m: number) => Note.chroma(Midi.midiToNoteName(m)), []);
+	const engine = useMemo(() => new ValidatorEngine(timeline, project), [timeline, project]);
 	useDeepCompareEffect(() => {
-		if (waitingUntilEmpty) {
-			return;
-		}
-
-		// Allow restarting from the first index if the first part is played after an incorrect attempt
-		if (
-			multiPartCardIndex !== 0 &&
-			wrongIndex === multiPartCardIndex &&
-			areArraysEqual(onNotesChroma, firstPartNotesChroma)
-		) {
-			dispatch(schedulerActions.startFromBeginningOfCurrentCard());
-			setWrongIndex(-1);
-			return;
-		}
-
-		// Validate notes for the current part
-		for (let i = 0; i < onNotesChroma.length; i++) {
-			if (!answerPartNotesChroma.includes(onNotesChroma[i])) {
-				dispatch(recordAttempt(false));
-				setWrongIndex(multiPartCardIndex);
-				dispatch(midiActions.addWrongNote(onNotesMidi[i]));
-				return;
-			}
-		}
-
-		const partComplete = onNotesChroma.length === answerPartNotesChroma.length;
-		if (partComplete) {
-			if (areArraysEqual(onNotesChroma, answerPartNotesChroma)) {
-				if (multiPartCardIndex === card.question.voices[0].stack.length - 1) {
-					dispatch(recordAttempt(true));
-				} else {
-					dispatch(midiActions.waitUntilEmpty());
-					dispatch(schedulerActions.incrementMultiPartCardIndex());
-				}
-			} else {
-				alert('Correct notes but incorrect order');
-			}
-		}
-	}, [onNotesChroma, answerPartNotesChroma, waitingUntilEmpty]);
-
+		engine.handle({
+			onNotes: onNotes.map((n) => n.number),
+			waiting,
+			index,
+			dispatch,
+		});
+	}, [onNotes, waiting, index]);
 	return null;
 };

--- a/packages/MemoryFlashCore/src/lib/ValidatorEngine.ts
+++ b/packages/MemoryFlashCore/src/lib/ValidatorEngine.ts
@@ -1,0 +1,73 @@
+import { activeNotesAt, computeTieAdvance, ScoreTimeline } from './scoreTimeline';
+import { midiActions } from '../redux/slices/midiSlice';
+import { schedulerActions } from '../redux/slices/schedulerSlice';
+import { recordAttempt } from '../redux/actions/record-attempt-action';
+import { AppDispatch } from '../redux/store';
+
+export type ProjectFn = (midi: number) => number;
+
+interface HandleArgs {
+	onNotes: number[];
+	waiting: boolean;
+	index: number;
+	dispatch: AppDispatch;
+}
+
+export class ValidatorEngine {
+	private prev: number[] = [];
+	private timings = new Map<number, { start?: number; end?: number }>();
+	constructor(
+		private timeline: ScoreTimeline,
+		private project: ProjectFn = (n) => n,
+	) {}
+
+	handle({ onNotes, waiting, index, dispatch }: HandleArgs): void {
+		this.updateTimings(onNotes);
+		if (waiting) return;
+		const expected = activeNotesAt(this.timeline, index).map(this.project);
+		const played = onNotes.map(this.project);
+		if (!this.matches(played, expected)) {
+			this.onWrong(played, expected, onNotes, dispatch);
+			return;
+		}
+		if (played.length === expected.length) this.onCorrect(index, dispatch);
+	}
+
+	private matches(played: number[], expected: number[]): boolean {
+		return played.every((n) => expected.includes(n));
+	}
+
+	private onWrong(
+		played: number[],
+		expected: number[],
+		raw: number[],
+		dispatch: AppDispatch,
+	): void {
+		dispatch(recordAttempt(false));
+		const wrong = played.find((n) => !expected.includes(n));
+		if (typeof wrong === 'number')
+			dispatch(midiActions.addWrongNote(raw[played.indexOf(wrong)]));
+		dispatch(midiActions.waitUntilEmpty());
+	}
+
+	private onCorrect(index: number, dispatch: AppDispatch): void {
+		dispatch(midiActions.waitUntilEmpty());
+		const { nextIndex, isCompleted } = computeTieAdvance(this.timeline, index);
+		if (isCompleted) dispatch(recordAttempt(true));
+		else
+			for (let i = 0; i < nextIndex - index; i++)
+				dispatch(schedulerActions.incrementMultiPartCardIndex());
+	}
+
+	private updateTimings(onNotes: number[]): void {
+		const now = Date.now();
+		const added = onNotes.filter((n) => !this.prev.includes(n));
+		const removed = this.prev.filter((n) => !onNotes.includes(n));
+		added.forEach((n) => this.timings.set(n, { start: now }));
+		removed.forEach((n) => {
+			const t = this.timings.get(n);
+			if (t) t.end = now;
+		});
+		this.prev = onNotes;
+	}
+}

--- a/packages/MemoryFlashCore/src/lib/scoreTimeline.ts
+++ b/packages/MemoryFlashCore/src/lib/scoreTimeline.ts
@@ -1,0 +1,64 @@
+import { Note } from 'tonal';
+import { MultiSheetCard } from '../types/MultiSheetCard';
+import { durationBeats } from './measure';
+
+export interface NoteEvent {
+	midi: number;
+	voice: number;
+	start: number;
+	end: number;
+}
+
+export interface ScoreTimeline {
+	events: NoteEvent[];
+	beats: number[];
+}
+
+export function buildScoreTimeline(card: MultiSheetCard): ScoreTimeline {
+	const events: NoteEvent[] = [];
+	card.question.voices.forEach((v, voice) => {
+		let beat = 0;
+		v.stack.forEach((s) => {
+			const len = durationBeats[s.duration];
+			s.notes.forEach((n) => {
+				const midi = Note.midi(n.name + n.octave);
+				if (typeof midi === 'number')
+					events.push({ midi, voice, start: beat, end: beat + len });
+			});
+			beat += len;
+		});
+	});
+	const beats = Array.from(new Set(events.flatMap((e) => [e.start, e.end]).concat(0))).sort(
+		(a, b) => a - b,
+	);
+	return { events, beats };
+}
+
+export function activeNotesAt(t: ScoreTimeline, index: number): number[] {
+	const beat = t.beats[index];
+	return t.events
+		.filter((e) => e.start <= beat && beat < e.end)
+		.map((e) => e.midi)
+		.sort((a, b) => a - b);
+}
+
+export function arraysEqual(a: number[], b: number[]): boolean {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
+
+export function computeTieAdvance(
+	t: ScoreTimeline,
+	index: number,
+): { nextIndex: number; isCompleted: boolean } {
+	const last = t.beats.length - 2;
+	let idx = index;
+	const curr = activeNotesAt(t, idx);
+	while (idx < last) {
+		const next = activeNotesAt(t, idx + 1);
+		if (arraysEqual(curr, next)) idx += 1;
+		else return { nextIndex: idx + 1, isCompleted: false };
+	}
+	return { nextIndex: idx, isCompleted: true };
+}


### PR DESCRIPTION
## Summary
- build ScoreTimeline from MultiSheet cards
- add ValidatorEngine to compare MIDI input with expected notes
- wire Exact/UnExact validators to new engine

## Testing
- `yarn test:codex`

------
https://chatgpt.com/codex/tasks/task_e_68c6fcb4aa748328a3f32faaf22e4f9e