### PR TITLE
Fix course and deck buttons requiring double tap on touch devices

### DIFF
--- a/apps/react/src/components/SectionCard.tsx
+++ b/apps/react/src/components/SectionCard.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Card } from './Card';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 interface SectionCardProps {
 	title: string;
@@ -19,6 +19,11 @@ export const SectionCard: React.FC<SectionCardProps> = ({
 	link,
 	menu,
 }) => {
+	const navigate = useNavigate();
+	const handleClick = useCallback(() => {
+		navigate(link);
+	}, [navigate, link]);
+
 	return (
 		<Card
 			className={`w-44 h-44 group ${className}`}
@@ -34,12 +39,13 @@ export const SectionCard: React.FC<SectionCardProps> = ({
 				{subTitle && <div className="text-[0.6rem]">{subTitle}</div>}
 			</div>
 
-			<Link
+			<button
+				type="button"
 				className="rounded-md w-full bg-blue-500 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 text-center"
-				to={link}
+				onClick={handleClick}
 			>
 				{btnText}
-			</Link>
+			</button>
 		</Card>
 	);
 };


### PR DESCRIPTION
## Summary
- navigate course and deck actions with an explicit click handler so they respond to a single tap
- replace the react-router Link in SectionCard with a button that calls useNavigate

## Testing
- yarn test:codex

------
https://chatgpt.com/codex/tasks/task_e_68cbab2218b48328a6bfc328b4f5408c