### PR TITLE
Fix custom deck study test to use card options menu

### DIFF
--- a/apps/react/tests/custom-deck-notation-to-study.spec.ts
+++ b/apps/react/tests/custom-deck-notation-to-study.spec.ts
@@ -116,7 +116,9 @@ test('Create custom deck, add notation and text cards, then study', async ({
 	// Navigate to the list and delete the first (notation) card
 	await page.click('a[href="list"], a[href$="/list"]');
 	await page.waitForURL(new RegExp(`/study/${deckId}/list`));
-	await page.locator('.card-container').first().locator('.absolute.right-1.bottom-1').click();
+	const firstCard = page.locator('.card-container').first();
+	await firstCard.getByRole('button', { name: 'Card options' }).click();
+	await page.getByRole('menuitem', { name: 'Delete card' }).click();
 	const [deleteResp3] = await Promise.all([
 		page.waitForResponse(
 			(r) => r.url().includes('/cards/') && r.request().method() === 'DELETE',


### PR DESCRIPTION
## Summary
- update the custom deck notation-to-study Playwright test to open the card options menu before deleting a card
- align the list view deletion steps with the new three-dot menu flow

## Testing
- yarn test:codex

------
https://chatgpt.com/codex/tasks/task_e_68cdfc5804c08328a7b10e116f875ae6