### PR TITLE
Align multi-staff notation rendering

### DIFF
--- a/apps/react/src/components/MusicNotation.tsx
+++ b/apps/react/src/components/MusicNotation.tsx
@@ -47,6 +47,20 @@ interface MusicNotationProps {
 
 type IndexedSn = { sn: Voice['stack'][0]; idx: number };
 
+type StaffRenderData = {
+	stave: Stave;
+	notes: StaveNote[];
+	beams: Beam[];
+	tieSpecs: Array<{
+		first: StaveNote;
+		last: StaveNote;
+		firstIndices: number[];
+		lastIndices: number[];
+	}>;
+	textVoice: VFVoice | null;
+	voice: VFVoice | null;
+};
+
 // Split a flat stack into measures of up to BEATS_PER_MEASURE beats
 function splitMeasures(indexed: IndexedSn[]) {
 	const measures: IndexedSn[][] = [];
@@ -106,7 +120,7 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 			const x = bar * BAR_WIDTH;
 			const isFirstBar = bar === 0;
 
-			const drawStaff = (staffType: StaffEnum, y: number) => {
+			const buildStaff = (staffType: StaffEnum, y: number): StaffRenderData => {
 				const stave = new VF.Stave(x, y, BAR_WIDTH);
 				if (isFirstBar) {
 					stave
@@ -116,18 +130,13 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 				}
 				stave.setContext(ctx).draw();
 
-				// Notes/rests for this bar & voice
 				const vIdx = data.voices.findIndex((v) => v.staff === staffType);
-				const stack = measuresByVoice[vIdx][bar] || [];
+				const stack = vIdx >= 0 ? measuresByVoice[vIdx][bar] || [] : [];
 				let beat = 0;
 				const notes: StaveNote[] = [];
-				const tieSpecs: Array<{
-					first: StaveNote;
-					last: StaveNote;
-					firstIndices: number[];
-					lastIndices: number[];
-				}> = [];
+				const tieSpecs: StaffRenderData['tieSpecs'] = [];
 				let pendingTie: { note: StaveNote; indices: number[] } | null = null;
+
 				stack.forEach(({ sn }) => {
 					const isRest = sn.rest || sn.notes.length === 0;
 					const restKey = staffType === StaffEnum.Bass ? 'd/3' : 'b/4';
@@ -179,26 +188,12 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 					notes.push(note);
 					beat += durationBeats[sn.duration];
 				});
+
 				const beams = VF.Beam.generateBeams(notes);
 
-				if (notes.length) {
-					VF.Formatter.FormatAndDraw(ctx, stave, notes);
-					beams.forEach((b) => b.setContext(ctx).draw());
-					tieSpecs.forEach((spec) =>
-						new VF.StaveTie({
-							first_note: spec.first,
-							last_note: spec.last,
-							first_indices: spec.firstIndices,
-							last_indices: spec.lastIndices,
-						})
-							.setContext(ctx)
-							.draw(),
-					);
-				}
-
-				// --- CHORD TEXT: wrap in a Voice, format, then draw ---
+				let textVoice: VFVoice | null = null;
 				if (!hideChords && staffType === StaffEnum.Treble) {
-					const textNotes = (chordMeasures[bar] || []).map(({ sn }) => {
+					const textNotes = (chordMeasures?.[bar] || []).map(({ sn }) => {
 						if (!sn.chordName) {
 							return new VF.TextNote({ text: '', duration: sn.duration }).setStave(
 								stave,
@@ -233,27 +228,74 @@ export const MusicNotation: React.FC<MusicNotationProps> = ({
 					});
 
 					if (textNotes.length) {
-						const textVoice = new VF.Voice({
+						textVoice = new VF.Voice({
 							num_beats: BEATS_PER_MEASURE,
 							beat_value: 4,
-						}).addTickables(textNotes);
+						})
+							.setStrict(false)
+							.addTickables(textNotes);
 
 						const textFormatter = new VF.Formatter();
 						textFormatter.joinVoices([textVoice]);
 						textFormatter.formatToStave([textVoice], stave);
-						textVoice.draw(ctx, stave);
 					}
 				}
 
-				// Draw barline at end of this measure
+				return { stave, notes, beams, tieSpecs, textVoice, voice: null };
+			};
+
+			const staffEntries: StaffRenderData[] = [];
+			if (trebleOn) staffEntries.push(buildStaff(StaffEnum.Treble, 20));
+			if (bassOn) staffEntries.push(buildStaff(StaffEnum.Bass, trebleOn ? 120 : 20));
+
+			const voices: VFVoice[] = [];
+			staffEntries.forEach((entry) => {
+				if (!entry.notes.length) return;
+				entry.voice = new VF.Voice({
+					num_beats: BEATS_PER_MEASURE,
+					beat_value: 4,
+				})
+					.setStrict(false)
+					.addTickables(entry.notes);
+				voices.push(entry.voice);
+			});
+
+			if (voices.length) {
+				const formatter = new VF.Formatter();
+				const referenceEntry = staffEntries.find((entry) => entry.voice);
+				const availableWidth = referenceEntry
+					? Math.max(
+							referenceEntry.stave.getWidth() -
+								referenceEntry.stave.getNoteStartX() -
+								10,
+							0,
+						)
+					: BAR_WIDTH - 20;
+				formatter.format(voices, availableWidth);
+
+				staffEntries.forEach((entry) => {
+					entry.voice?.draw(ctx, entry.stave);
+					entry.beams.forEach((b) => b.setContext(ctx).draw());
+					entry.tieSpecs.forEach((spec) =>
+						new VF.StaveTie({
+							first_note: spec.first,
+							last_note: spec.last,
+							first_indices: spec.firstIndices,
+							last_indices: spec.lastIndices,
+						})
+							.setContext(ctx)
+							.draw(),
+					);
+					entry.textVoice?.draw(ctx, entry.stave);
+				});
+			}
+
+			staffEntries.forEach((entry) => {
 				new VF.Barline(VF.Barline.type.SINGLE)
 					.setContext(ctx)
 					.setX(x + BAR_WIDTH)
-					.draw(stave);
-			};
-
-			if (trebleOn) drawStaff(StaffEnum.Treble, 20);
-			if (bassOn) drawStaff(StaffEnum.Bass, trebleOn ? 120 : 20);
+					.draw(entry.stave);
+			});
 		}
 	}, [data, multiPartCardIndex, allNotesClassName, highlightClassName, hideChords]);
 

--- a/apps/react/tests/music-notation-alignment-test.tsx
+++ b/apps/react/tests/music-notation-alignment-test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+import { renderApp } from './renderApp';
+
+const data: MultiSheetQuestion = {
+	key: 'G',
+	voices: [
+		{
+			staff: StaffEnum.Treble,
+			stack: [
+				{ notes: [], duration: 'q', rest: true },
+				{ notes: [{ name: 'B', octave: 3 }], duration: '16' },
+				{ notes: [{ name: 'A', octave: 3 }], duration: '8' },
+				{ notes: [{ name: 'G', octave: 3 }], duration: '8' },
+				{ notes: [{ name: 'E', octave: 3 }], duration: '16' },
+				{ notes: [{ name: 'D', octave: 3 }], duration: 'qd' },
+			],
+		},
+		{
+			staff: StaffEnum.Bass,
+			stack: [
+				{ notes: [{ name: 'G', octave: 2 }], duration: 'hd' },
+				{ notes: [{ name: 'G', octave: 2 }], duration: 'q' },
+			],
+		},
+	],
+};
+
+renderApp(<MusicNotation data={data} />);


### PR DESCRIPTION
## Summary
- format treble and bass voices together so beats align across staves in MusicNotation
- preserve chord symbols and ties while drawing barlines after layout
- add a screenshot regression test covering the reported G major multi-sheet card

## Testing
- yarn test:codex

------
https://chatgpt.com/codex/tasks/task_e_68ce056b21988328a955d2e4ade31564