### PR TITLE
Use runRecorderEvents in notation overflow test

### DIFF
--- a/apps/react/tests/notation-input-overflow.spec.ts
+++ b/apps/react/tests/notation-input-overflow.spec.ts
@@ -1,21 +1,9 @@
-import { test, expect } from './helpers';
+import { test, runRecorderEvents } from './helpers';
 
 test('NotationInputScreen handles overflow input', async ({ page }) => {
 	await page.goto('/tests/notation-input-screen-test.html');
 	await page.locator('#root').waitFor();
 
-	const press = async (midi: number) => {
-		await page.evaluate((n) => {
-			(window as any).store.dispatch({ type: 'midi/addNote', payload: n });
-		}, midi);
-		await page.evaluate((n) => {
-			(window as any).store.dispatch({ type: 'midi/removeNote', payload: n });
-		}, midi);
-	};
-
-	for (const m of [60, 62, 64, 65]) {
-		await press(m);
-	}
-	await press(67);
+	await runRecorderEvents(page, undefined, [[60], [62], [64], [65], [67]]);
 	await page.waitForTimeout(200);
 });


### PR DESCRIPTION
## Summary
- replace the inline MIDI note dispatch helper in the notation overflow Playwright spec with the shared runRecorderEvents utility
- continue to rely on the existing NotationInput navigation while reusing the central recorder helper for consistent note handling

## Testing
- yarn test:codex

------
https://chatgpt.com/codex/tasks/task_e_68ced9f40ce08328a054666ad04bb101