### PR TITLE
Improve multi-staff layout alignment

### DIFF
--- a/apps/react/tests/music-notation-alignment-test.tsx
+++ b/apps/react/tests/music-notation-alignment-test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { MusicNotation } from '../src/components/MusicNotation';
+import '../src/index.css';
+import { MultiSheetQuestion } from 'MemoryFlashCore/src/types/MultiSheetCard';
+import { StaffEnum } from 'MemoryFlashCore/src/types/Cards';
+import { renderApp } from './renderApp';
+
+const data: MultiSheetQuestion = {
+	key: 'G',
+	voices: [
+		{
+			staff: StaffEnum.Treble,
+			stack: [
+				{ notes: [], duration: 'q', rest: true },
+				{ notes: [{ name: 'B', octave: 3 }], duration: '16' },
+				{ notes: [{ name: 'A', octave: 3 }], duration: '8' },
+				{ notes: [{ name: 'G', octave: 3 }], duration: '8' },
+				{ notes: [{ name: 'E', octave: 3 }], duration: '16' },
+				{ notes: [{ name: 'D', octave: 3 }], duration: 'qd' },
+			],
+		},
+		{
+			staff: StaffEnum.Bass,
+			stack: [
+				{ notes: [{ name: 'G', octave: 2 }], duration: 'hd' },
+				{ notes: [{ name: 'G', octave: 2 }], duration: 'q' },
+			],
+		},
+	],
+};
+
+renderApp(<MusicNotation data={data} />);


### PR DESCRIPTION
## Summary
- join simultaneous VexFlow voices before formatting so treble and bass beats share the same spacing
- derive consistent multi-staff renderer height from explicit top, bottom, and inter-staff spacing so SVGs avoid extra whitespace

## Testing
- yarn test:codex

------
https://chatgpt.com/codex/tasks/task_e_68ce056b21988328a955d2e4ade31564