### PR TITLE
Normalize Playwright rendering flags

### DIFF
--- a/apps/react/playwright.config.ts
+++ b/apps/react/playwright.config.ts
@@ -17,9 +17,17 @@ export default defineConfig({
 			reuseExistingServer: !process.env.CI,
 		},
 	],
-	use: {
-		baseURL: 'http://localhost:4173',
-		screenshot: 'only-on-failure',
-	},
+        use: {
+                baseURL: 'http://localhost:4173',
+                screenshot: 'only-on-failure',
+                // Normalize rendering differences between macOS and Linux in CI runs.
+                launchOptions: {
+                        args: [
+                                '--force-device-scale-factor=1',
+                                '--disable-font-subpixel-positioning',
+                                '--disable-lcd-text',
+                        ],
+                },
+        },
 	reporter: [['html', { open: 'never' }]],
 });


### PR DESCRIPTION
## Summary
- add Chromium launch flags to the Playwright config so snapshots render consistently across macOS and CI
- document that the launch options target cross-platform parity for future maintainers

## Testing
- yarn test:codex

------
https://chatgpt.com/codex/tasks/task_e_68ce0690b4888328ae6037ff6f43ed09