### PR TITLE
Improve chord memory card text prompt typography

### DIFF
--- a/apps/react/src/components/FlashCard.tsx
+++ b/apps/react/src/components/FlashCard.tsx
@@ -49,13 +49,13 @@ export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
 		return (
 			<div
 				ref={ref}
-				className={`card-container flex flex-col items-center min-w-[15rem] m-h-60 m-4 ${className}`}
+				className={`relative card-container flex flex-col justify-between items-center min-w-[15rem] m-h-60 m-4 ${className}`}
 				style={{
 					opacity,
 					transition: 'opacity 0.5s ease',
 				}}
 			>
-				<div className="w-full flex justify-end -mb-2">
+				<div className="absolute right-1 top-1">
 					<FlashCardOptionsMenu card={card} showEdit={showEdit} showDelete={showDelete} />
 				</div>
 				<div className="text-4xl font-medium flex flex-1 justify-center items-center">

--- a/apps/react/src/components/FlashCard.tsx
+++ b/apps/react/src/components/FlashCard.tsx
@@ -49,13 +49,13 @@ export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
 		return (
 			<div
 				ref={ref}
-				className={`relative card-container flex flex-col justify-between items-center min-w-[15rem] m-h-60  m-4 ${className}`}
+				className={`card-container flex flex-col items-center min-w-[15rem] m-h-60 m-4 ${className}`}
 				style={{
 					opacity,
 					transition: 'opacity 0.5s ease',
 				}}
 			>
-				<div className="absolute right-1 top-1">
+				<div className="w-full flex justify-end -mb-2">
 					<FlashCardOptionsMenu card={card} showEdit={showEdit} showDelete={showDelete} />
 				</div>
 				<div className="text-4xl font-medium flex flex-1 justify-center items-center">

--- a/apps/react/src/components/FlashCard.tsx
+++ b/apps/react/src/components/FlashCard.tsx
@@ -49,13 +49,13 @@ export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
 		return (
 			<div
 				ref={ref}
-				className={`relative card-container flex flex-col justify-between items-center min-w-[15rem] m-h-60 m-4 ${className}`}
+				className={`card-container flex flex-col items-center min-w-[15rem] m-h-60 m-4 ${className}`}
 				style={{
 					opacity,
 					transition: 'opacity 0.5s ease',
 				}}
 			>
-				<div className="absolute right-1 top-1">
+				<div className="w-full flex justify-end -mb-3">
 					<FlashCardOptionsMenu card={card} showEdit={showEdit} showDelete={showDelete} />
 				</div>
 				<div className="text-4xl font-medium flex flex-1 justify-center items-center">

--- a/apps/react/src/components/FlashCard.tsx
+++ b/apps/react/src/components/FlashCard.tsx
@@ -49,13 +49,13 @@ export const FlashCard = forwardRef<HTMLDivElement, FlashCardProps>(
 		return (
 			<div
 				ref={ref}
-				className={`card-container flex flex-col items-center min-w-[15rem] m-h-60 m-4 ${className}`}
+				className={`card-container flex flex-col justify-between items-center min-w-[15rem] m-h-60 m-4 ${className}`}
 				style={{
 					opacity,
 					transition: 'opacity 0.5s ease',
 				}}
 			>
-				<div className="w-full flex justify-end -mb-3">
+				<div className="relative z-10 w-full flex justify-end -mb-9">
 					<FlashCardOptionsMenu card={card} showEdit={showEdit} showDelete={showDelete} />
 				</div>
 				<div className="text-4xl font-medium flex flex-1 justify-center items-center">

--- a/apps/react/src/components/FlashCards/TextCardPrompt.tsx
+++ b/apps/react/src/components/FlashCards/TextCardPrompt.tsx
@@ -19,7 +19,7 @@ export const TextCardPrompt: React.FC<TextCardPromptProps> = ({
 			components={{
 				h1: ({ children }) => <p className="heading-lg">{children}</p>,
 				h2: ({ children }) => <p className="caption">{children}</p>,
-				p: ({ children }) => <p className="heading-lg">{children}</p>,
+				p: ({ children }) => <p className="heading-md">{children}</p>,
 			}}
 		>
 			{text}

--- a/apps/react/src/components/FlashCards/TextCardPrompt.tsx
+++ b/apps/react/src/components/FlashCards/TextCardPrompt.tsx
@@ -14,7 +14,14 @@ export const TextCardPrompt: React.FC<TextCardPromptProps> = ({
 	correctCount = 0,
 }) => (
 	<div className="flex flex-col items-center justify-center text-center gap-2">
-		<ReactMarkdown className="prose prose-sm max-w-none dark:prose-invert pt-3">
+		<ReactMarkdown
+			className="max-w-none pt-3 flex flex-col items-center gap-1"
+			components={{
+				h1: ({ children }) => <p className="heading-lg">{children}</p>,
+				h2: ({ children }) => <p className="caption">{children}</p>,
+				p: ({ children }) => <p className="heading-lg">{children}</p>,
+			}}
+		>
 			{text}
 		</ReactMarkdown>
 		<div className="mb-auto">


### PR DESCRIPTION
## Summary
- Replace `prose prose-sm` with custom `react-markdown` component overrides in `TextCardPrompt`
- `# Title` → `heading-lg` (large, bold) for song/piece names
- `## Label` → `caption` (small, muted) for section labels
- Plain text → `heading-lg` so single-line prompts like `Cm7` render at proper flashcard size

## Test plan
- [x] `yarn test:codex` — all 94 tests pass
- [ ] Screenshot tests — check CI results (rendering changes expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)